### PR TITLE
Fix role privilege reconcile for non superusers

### DIFF
--- a/pkg/controller/postgresql/role/reconciler.go
+++ b/pkg/controller/postgresql/role/reconciler.go
@@ -54,6 +54,7 @@ const (
 	errDropRole                = "cannot drop role"
 	errUpdateRole              = "cannot update role"
 	errGetPasswordSecretFailed = "cannot get password secret"
+	errComparePrivileges       = "cannot compare desired and observed privileges"
 )
 
 // Setup adds a controller that reconciles Role managed resources.
@@ -150,8 +151,15 @@ func privilegesToClauses(p v1alpha1.RolePrivilege) []string {
 	return pc
 }
 
-func changedPrivs(existing []string, desired []string) []string {
+func changedPrivs(existing []string, desired []string) ([]string, error) {
 	out := []string{}
+
+	// Make sure existing observation has at least as many items as
+	// desired. If it does not, then we cannot safely compare
+	// privileges.
+	if len(existing) < len(desired) {
+		return nil, errors.New(errComparePrivileges)
+	}
 
 	// The input slices here are outputted by privilegesToClauses above.
 	// Because these are created by repeated calls to negateClause in the
@@ -163,7 +171,7 @@ func changedPrivs(existing []string, desired []string) []string {
 			out = append(out, v)
 		}
 	}
-	return out
+	return out, nil
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -282,7 +290,11 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}, nil
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) { //nolint:gocyclo
+	// NOTE(benagricola): This is just a touch over the cyclomatic complexity
+	// limit, but is unlikely to become more complex unless new role features
+	// are added. Think about splitting this method up if new functionality
+	// is desired.
 	cr, ok := mg.(*v1alpha1.Role)
 	if !ok {
 		return managed.ExternalUpdate{}, errors.New(errNotRole)
@@ -304,7 +316,11 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	privs := privilegesToClauses(cr.Spec.ForProvider.Privileges)
-	cp := changedPrivs(cr.Status.AtProvider.PrivilegesAsClauses, privs)
+	cp, err := changedPrivs(cr.Status.AtProvider.PrivilegesAsClauses, privs)
+
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateRole)
+	}
 
 	if len(cp) > 0 {
 		if err := c.db.Exec(ctx, xsql.Query{

--- a/pkg/controller/postgresql/role/reconciler_test.go
+++ b/pkg/controller/postgresql/role/reconciler_test.go
@@ -19,11 +19,13 @@ package role
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/crossplane-contrib/provider-sql/apis/postgresql/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -594,7 +596,6 @@ func TestUpdate(t *testing.T) {
 				c:   managed.ExternalUpdate{},
 			},
 		},
-		// WILL FAIL
 		"SamePassword": {
 			reason: "No DB query should be executed if the password didn't change",
 			fields: fields{
@@ -699,6 +700,118 @@ func TestUpdate(t *testing.T) {
 						xpv1.ResourceCredentialsSecretPortKey:     []byte("5432"),
 					},
 				},
+			},
+		},
+		"NoUpdateUnchangedPrivs": {
+			reason: "We should only try to set privileges whose values have changed.",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						// Verify that query contains only the identifier that we
+						// expect, otherwise return a boom.
+						crn := pq.QuoteIdentifier("example")
+						if q.String != fmt.Sprintf("ALTER ROLE %s NOINHERIT", crn) {
+							return errBoom
+						}
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Role{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							meta.AnnotationKeyExternalName: "example",
+						},
+					},
+					Spec: v1alpha1.RoleSpec{
+						ForProvider: v1alpha1.RoleParameters{
+							PasswordSecretRef: &xpv1.SecretKeySelector{
+								SecretReference: xpv1.SecretReference{
+									Name: "connection-secret",
+								},
+								Key: xpv1.ResourceCredentialsSecretPasswordKey,
+							},
+							Privileges: v1alpha1.RolePrivilege{
+								Login:   pointer.BoolPtr(true),
+								Inherit: pointer.BoolPtr(false),
+							},
+						},
+					},
+					Status: v1alpha1.RoleStatus{
+						AtProvider: v1alpha1.RoleObservation{
+							// Observed status vs. Requested status means we should ALTER
+							// to NOINHERIT. Order is important here, make sure this
+							// matches the order in privilegesToClauses()
+							PrivilegesAsClauses: []string{"INHERIT", "LOGIN"},
+						},
+					},
+				},
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						secret := corev1.Secret{
+							Data: map[string][]byte{},
+						}
+						secret.Data[xpv1.ResourceCredentialsSecretPasswordKey] = []byte("samesame")
+						secret.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					},
+				},
+			},
+			want: want{},
+		},
+		"NoUpdateQueryNoChangedPrivs": {
+			reason: "We should not execute an SQL query if privileges are unchanged.",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return errBoom
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Role{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							meta.AnnotationKeyExternalName: "example",
+						},
+					},
+					Spec: v1alpha1.RoleSpec{
+						ForProvider: v1alpha1.RoleParameters{
+							PasswordSecretRef: &xpv1.SecretKeySelector{
+								SecretReference: xpv1.SecretReference{
+									Name: "connection-secret",
+								},
+								Key: xpv1.ResourceCredentialsSecretPasswordKey,
+							},
+							Privileges: v1alpha1.RolePrivilege{
+								Login:   pointer.BoolPtr(true),
+								Inherit: pointer.BoolPtr(false),
+							},
+						},
+					},
+					Status: v1alpha1.RoleStatus{
+						AtProvider: v1alpha1.RoleObservation{
+							// Observed privileges are the same as requested,
+							// and in the same order. We should not make any
+							// query to update privileges.
+							PrivilegesAsClauses: []string{"NOINHERIT", "LOGIN"},
+						},
+					},
+				},
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						secret := corev1.Secret{
+							Data: map[string][]byte{},
+						}
+						secret.Data[xpv1.ResourceCredentialsSecretPasswordKey] = []byte("samesame")
+						secret.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					},
+				},
+			},
+			want: want{
+				err: nil,
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes
When a postgres role change is detected, `provider-sql` now compares the list of provided privileges against the observed list of privileges, and only updates the privileges which have changed. This avoids throwing errors for privileges which have not actually changed (and that our non-superuser `provider-sql` user cannot change after creation).

I've added tests to confirm:
1) Only updated privileges are put into an `ALTER ROLE ...` query
2) If no privileges are changed, no query is executed

Fixes #25

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Additional tests have been written as per above, and the provider has been built and run locally against the RDS postgres instance that was exhibiting the original issue to confirm that the resource is reconciled correctly.
