### PR TITLE
Use pg_roles to lookup postgres grants

### DIFF
--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -170,8 +170,8 @@ func selectGrantQuery(gp v1alpha1.GrantParameters, q *xsql.Query) error {
 		// if this is used with a nonexistent role name it will
 		// throw an error rather than return false.
 		q.String = "SELECT EXISTS(SELECT 1 FROM pg_auth_members m " +
-			"INNER JOIN pg_authid mo ON m.roleid = mo.oid " +
-			"INNER JOIN pg_authid r ON m.member = r.oid " +
+			"INNER JOIN pg_roles mo ON m.roleid = mo.oid " +
+			"INNER JOIN pg_roles r ON m.member = r.oid " +
 			"WHERE r.rolname=$1 AND mo.rolname=$2 AND " +
 			"m.admin_option = $3)"
 
@@ -190,7 +190,7 @@ func selectGrantQuery(gp v1alpha1.GrantParameters, q *xsql.Query) error {
 		q.String = "SELECT EXISTS(SELECT 1 " +
 			"FROM pg_database db, " +
 			"aclexplode(datacl) as acl " +
-			"INNER JOIN pg_authid s ON acl.grantee = s.oid " +
+			"INNER JOIN pg_roles s ON acl.grantee = s.oid " +
 			// Filter by database, role and grantable setting
 			"WHERE db.datname=$1 " +
 			"AND s.rolname=$2 " +


### PR DESCRIPTION
Another RDS gotcha - `pg_authid` is not available to non-superusers as it contains a password field (unused in the queries that we make).

`pg_roles` is a publicly accessible view into the same underlying data, without the password field, and must be used if provisioning using the `postgres` user on RDS. There is no downside to switching to this when using a real superuser.

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>


### Description of your changes
Changed all instances of `pg_authid` table usage to `pg_roles` as we don't use the password field.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Passes the test suite locally, and has been verified against the same RDS cluster that was causing the issue originally (first log line is from provider without this fix):

```
Events:
  Type     Reason                         Age                  From                                        Message
  ----     ------                         ----                 ----                                        -------
  Warning  CannotObserveExternalResource  6m8s (x93 over 21m)  managed/grant.postgresql.sql.crossplane.io  cannot select grant: pq: permission denied for table pg_authid
  Normal   CreatedExternalResource        2m44s                managed/grant.postgresql.sql.crossplane.io  Successfully requested creation of external resource
```
[contribution process]: https://git.io/fj2m9
