### PR TITLE
Fix a typo in the role deletion query

### DIFF
--- a/pkg/controller/postgresql/role/reconciler.go
+++ b/pkg/controller/postgresql/role/reconciler.go
@@ -327,7 +327,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 	cr.SetConditions(xpv1.Deleting())
 	err := c.db.Exec(ctx, xsql.Query{
-		String: "DROP ROLE IF EXISTS" + pq.QuoteIdentifier(meta.GetExternalName(cr)),
+		String: "DROP ROLE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(cr)),
 	})
 	return errors.Wrap(err, errDropRole)
 }


### PR DESCRIPTION
### Description of your changes
This one is a doozy by me - the role deletion query was missing a space, causing an SQL syntax error - however I missed this... because I had `deletionPolicy: Orphan` specified in my test resources 🤦

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Code has been tested against a real RDS instance, querying `pg_roles` to confirm successful deletion (with `deletionPolicy: Delete`) after deleting the managed resource. Tests still pass locally.

[contribution process]: https://git.io/fj2m9
