### PR TITLE
Fix ResolveReferences on Grant types

### DIFF
--- a/apis/mysql/v1alpha1/grant_types.go
+++ b/apis/mysql/v1alpha1/grant_types.go
@@ -132,26 +132,28 @@ func (mg *Grant) ResolveReferences(ctx context.Context, c client.Reader) error {
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Database),
 		Reference:    mg.Spec.ForProvider.DatabaseRef,
 		Selector:     mg.Spec.ForProvider.DatabaseSelector,
-		To:           reference.To{Managed: &Database{}},
+		To:           reference.To{Managed: &Database{}, List: &DatabaseList{}},
 		Extract:      reference.ExternalName(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "spec.forProvider.database")
 	}
 	mg.Spec.ForProvider.Database = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.DatabaseRef = rsp.ResolvedReference
 
 	// Resolve spec.forProvider.user
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.User),
 		Reference:    mg.Spec.ForProvider.UserRef,
 		Selector:     mg.Spec.ForProvider.UserSelector,
-		To:           reference.To{Managed: &User{}},
+		To:           reference.To{Managed: &User{}, List: &UserList{}},
 		Extract:      reference.ExternalName(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "spec.forProvider.user")
 	}
 	mg.Spec.ForProvider.User = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.UserRef = rsp.ResolvedReference
 
 	return nil
 }

--- a/apis/postgresql/v1alpha1/grant_types.go
+++ b/apis/postgresql/v1alpha1/grant_types.go
@@ -166,38 +166,41 @@ func (mg *Grant) ResolveReferences(ctx context.Context, c client.Reader) error {
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Database),
 		Reference:    mg.Spec.ForProvider.DatabaseRef,
 		Selector:     mg.Spec.ForProvider.DatabaseSelector,
-		To:           reference.To{Managed: &Database{}},
+		To:           reference.To{Managed: &Database{}, List: &DatabaseList{}},
 		Extract:      reference.ExternalName(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "spec.forProvider.database")
 	}
 	mg.Spec.ForProvider.Database = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.DatabaseRef = rsp.ResolvedReference
 
 	// Resolve spec.forProvider.role
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Role),
 		Reference:    mg.Spec.ForProvider.RoleRef,
 		Selector:     mg.Spec.ForProvider.RoleSelector,
-		To:           reference.To{Managed: &Role{}},
+		To:           reference.To{Managed: &Role{}, List: &RoleList{}},
 		Extract:      reference.ExternalName(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "spec.forProvider.role")
 	}
 	mg.Spec.ForProvider.Role = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.RoleRef = rsp.ResolvedReference
 
 	// Resolve spec.forProvider.memberOf
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.MemberOf),
 		Reference:    mg.Spec.ForProvider.MemberOfRef,
 		Selector:     mg.Spec.ForProvider.MemberOfSelector,
-		To:           reference.To{Managed: &Role{}},
+		To:           reference.To{Managed: &Role{}, List: &RoleList{}},
 		Extract:      reference.ExternalName(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "spec.forProvider.memberOf")
 	}
 	mg.Spec.ForProvider.MemberOf = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.MemberOfRef = rsp.ResolvedReference
 	return nil
 }


### PR DESCRIPTION
### Description of your changes

It appears that Resolving references from Selectors has not worked previously for either the MySQL or PostgreSQL Grant types. This is down to missing references to `List` for each referenced type, and potentially, not setting the `Ref` field to the resolved reference.

This commit adds the missing code, taking reference from a known-working `Selector` implementation in `provider-aws`.

Fixes #29

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
There are no existing tests for the `ResolveReferences()` methods and I have not seen any test implementations of these in other providers. I have tested the Postgres `Grant` `memberOfSelector` field on a live cluster, which is the one that was showing this issue for me originally, and these changes do fix that issue.

@srueg any chance you have a working MySQL implementation that uses `Selector` that this could be tested on? 🤔 
