### PR TITLE
add categories to CRDs

### DIFF
--- a/apis/mysql/v1alpha1/database_types.go
+++ b/apis/mysql/v1alpha1/database_types.go
@@ -39,7 +39,7 @@ type DatabaseStatus struct {
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type Database struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/mysql/v1alpha1/grant_types.go
+++ b/apis/mysql/v1alpha1/grant_types.go
@@ -105,7 +105,7 @@ type GrantStatus struct {
 // +kubebuilder:printcolumn:name="ROLE",type="string",JSONPath=".spec.forProvider.user"
 // +kubebuilder:printcolumn:name="DATABASE",type="string",JSONPath=".spec.forProvider.database"
 // +kubebuilder:printcolumn:name="PRIVILEGES",type="string",JSONPath=".spec.forProvider.privileges"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type Grant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/mysql/v1alpha1/provider_types.go
+++ b/apis/mysql/v1alpha1/provider_types.go
@@ -58,7 +58,7 @@ type ProviderConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority=1
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,sql}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -83,7 +83,7 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,sql}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/mysql/v1alpha1/provider_types.go
+++ b/apis/mysql/v1alpha1/provider_types.go
@@ -58,7 +58,7 @@ type ProviderConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority=1
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -83,7 +83,7 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/mysql/v1alpha1/user_types.go
+++ b/apis/mysql/v1alpha1/user_types.go
@@ -53,7 +53,7 @@ type UserObservation struct {
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type User struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/postgresql/v1alpha1/database_types.go
+++ b/apis/postgresql/v1alpha1/database_types.go
@@ -93,7 +93,7 @@ type DatabaseStatus struct {
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type Database struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/postgresql/v1alpha1/grant_types.go
+++ b/apis/postgresql/v1alpha1/grant_types.go
@@ -139,7 +139,7 @@ type GrantStatus struct {
 // +kubebuilder:printcolumn:name="MEMBER OF",type="string",JSONPath=".spec.forProvider.memberOf"
 // +kubebuilder:printcolumn:name="DATABASE",type="string",JSONPath=".spec.forProvider.database"
 // +kubebuilder:printcolumn:name="PRIVILEGES",type="string",JSONPath=".spec.forProvider.privileges"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type Grant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/postgresql/v1alpha1/provider_types.go
+++ b/apis/postgresql/v1alpha1/provider_types.go
@@ -83,7 +83,7 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,sql}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/postgresql/v1alpha1/provider_types.go
+++ b/apis/postgresql/v1alpha1/provider_types.go
@@ -58,7 +58,7 @@ type ProviderConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority=1
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -83,7 +83,7 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/postgresql/v1alpha1/provider_types.go
+++ b/apis/postgresql/v1alpha1/provider_types.go
@@ -58,7 +58,7 @@ type ProviderConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority=1
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,sql}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/postgresql/v1alpha1/role_types.go
+++ b/apis/postgresql/v1alpha1/role_types.go
@@ -100,7 +100,7 @@ type RoleObservation struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="CONN LIMIT",type="integer",JSONPath=".spec.forProvider.connectionLimit"
 // +kubebuilder:printcolumn:name="PRIVILEGES",type="string",JSONPath=".status.atProvider.privilegesAsClauses"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type Role struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/package/crds/mysql.sql.crossplane.io_databases.yaml
+++ b/package/crds/mysql.sql.crossplane.io_databases.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: mysql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: Database
     listKind: DatabaseList
     plural: databases

--- a/package/crds/mysql.sql.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.crossplane.io_grants.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: mysql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: Grant
     listKind: GrantList
     plural: grants

--- a/package/crds/mysql.sql.crossplane.io_providerconfigs.yaml
+++ b/package/crds/mysql.sql.crossplane.io_providerconfigs.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: mysql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: ProviderConfig
     listKind: ProviderConfigList
     plural: providerconfigs

--- a/package/crds/mysql.sql.crossplane.io_providerconfigs.yaml
+++ b/package/crds/mysql.sql.crossplane.io_providerconfigs.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     categories:
     - crossplane
-    - managed
+    - provider
     - sql
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/package/crds/mysql.sql.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/mysql.sql.crossplane.io_providerconfigusages.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     categories:
     - crossplane
-    - managed
+    - provider
     - sql
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList

--- a/package/crds/mysql.sql.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/mysql.sql.crossplane.io_providerconfigusages.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: mysql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages

--- a/package/crds/mysql.sql.crossplane.io_users.yaml
+++ b/package/crds/mysql.sql.crossplane.io_users.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: mysql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: User
     listKind: UserList
     plural: users

--- a/package/crds/postgresql.sql.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_databases.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: postgresql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: Database
     listKind: DatabaseList
     plural: databases

--- a/package/crds/postgresql.sql.crossplane.io_grants.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_grants.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: postgresql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: Grant
     listKind: GrantList
     plural: grants

--- a/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: postgresql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: ProviderConfig
     listKind: ProviderConfigList
     plural: providerconfigs

--- a/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     categories:
     - crossplane
-    - managed
+    - provider
     - sql
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/package/crds/postgresql.sql.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_providerconfigusages.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     categories:
     - crossplane
-    - managed
+    - provider
     - sql
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList

--- a/package/crds/postgresql.sql.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_providerconfigusages.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: postgresql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages

--- a/package/crds/postgresql.sql.crossplane.io_roles.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_roles.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: postgresql.sql.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - sql
     kind: Role
     listKind: RoleList
     plural: roles


### PR DESCRIPTION
### Description of your changes

To be able to get all managed resources of the provider-sql via `kubectl get managed` I extended all CRDs with the categories crossplane,managed,sql.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I installed the CRDs in my local cluster and verified if `kubectl get managed` results in my sql-provider managed resources.

