### PR TITLE
Allow database to be overridden in DSN from postgres constructor

### DIFF
--- a/pkg/clients/postgresql/postgresql.go
+++ b/pkg/clients/postgresql/postgresql.go
@@ -16,8 +16,10 @@ type postgresDB struct {
 	port     string
 }
 
-// New returns a new PostgreSQL database client.
-func New(creds map[string][]byte) xsql.DB {
+// New returns a new PostgreSQL database client. The default database name is
+// an empty string. The underlying pq library will default to either using the
+// value of PGDATABASE, or if unset, the hardcoded string 'postgres'.
+func New(creds map[string][]byte, database string) xsql.DB {
 	// TODO(negz): Support alternative connection secret formats?
 	endpoint := string(creds[xpv1.ResourceCredentialsSecretEndpointKey])
 	port := string(creds[xpv1.ResourceCredentialsSecretPortKey])
@@ -26,7 +28,8 @@ func New(creds map[string][]byte) xsql.DB {
 			string(creds[xpv1.ResourceCredentialsSecretUserKey]) + ":" +
 			string(creds[xpv1.ResourceCredentialsSecretPasswordKey]) + "@" +
 			endpoint + ":" +
-			port,
+			port + "/" +
+			database,
 		endpoint: endpoint,
 		port:     port,
 	}

--- a/pkg/controller/postgresql/database/reconciler.go
+++ b/pkg/controller/postgresql/database/reconciler.go
@@ -78,7 +78,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	kube  client.Client
 	usage resource.Tracker
-	newDB func(creds map[string][]byte) xsql.DB
+	newDB func(creds map[string][]byte, database string) xsql.DB
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -111,7 +111,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetSecret)
 	}
 
-	return &external{db: c.newDB(s.Data)}, nil
+	return &external{db: c.newDB(s.Data, "")}, nil
 }
 
 type external struct{ db xsql.DB }

--- a/pkg/controller/postgresql/database/reconciler_test.go
+++ b/pkg/controller/postgresql/database/reconciler_test.go
@@ -65,7 +65,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte) xsql.DB
+		newDB func(creds map[string][]byte, database string) xsql.DB
 	}
 
 	type args struct {

--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -79,7 +79,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	kube  client.Client
 	usage resource.Tracker
-	newDB func(creds map[string][]byte) xsql.DB
+	newDB func(creds map[string][]byte, database string) xsql.DB
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -112,7 +112,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetSecret)
 	}
 	return &external{
-		db:   c.newDB(s.Data),
+		db:   c.newDB(s.Data, ""),
 		kube: c.kube,
 	}, nil
 }

--- a/pkg/controller/postgresql/grant/reconciler_test.go
+++ b/pkg/controller/postgresql/grant/reconciler_test.go
@@ -69,7 +69,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte) xsql.DB
+		newDB func(creds map[string][]byte, database string) xsql.DB
 	}
 
 	type args struct {

--- a/pkg/controller/postgresql/role/reconciler.go
+++ b/pkg/controller/postgresql/role/reconciler.go
@@ -78,7 +78,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	kube  client.Client
 	usage resource.Tracker
-	newDB func(creds map[string][]byte) xsql.DB
+	newDB func(creds map[string][]byte, database string) xsql.DB
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -112,7 +112,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	}
 
 	return &external{
-		db:   c.newDB(s.Data),
+		db:   c.newDB(s.Data, ""),
 		kube: c.kube,
 	}, nil
 }

--- a/pkg/controller/postgresql/role/reconciler_test.go
+++ b/pkg/controller/postgresql/role/reconciler_test.go
@@ -73,7 +73,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte) xsql.DB
+		newDB func(creds map[string][]byte, database string) xsql.DB
 	}
 
 	type args struct {


### PR DESCRIPTION
### Description of your changes
This is in preparation for further functionality where the connection database name for the PostgreSQL client needs to be controlled dynamically, e.g. where resources must be created under a particular database. We must _connect_ on a particular database to be able to create resources on that db (e.g. Extensions).

Fixes #34

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

There are no tests that cover the SQL client functionality directly. 

The existing test suite still passes, and I have tested this code on a local kind cluster, both with and without overriding the database. I've also confirmed the expected behaviour when using `PGDATABASE=blah`, and making sure this is still used if an empty string is set when calling `postgresql.New()`

[contribution process]: https://git.io/fj2m9
