### PR TITLE
Add sslmode option for PostgreSQL

### DIFF
--- a/apis/postgresql/v1alpha1/provider_types.go
+++ b/apis/postgresql/v1alpha1/provider_types.go
@@ -26,6 +26,11 @@ import (
 type ProviderConfigSpec struct {
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`
+	// Defines the SSL mode used to set up a connection to the provided
+	// PostgreSQL instance
+	// +kubebuilder:validation:Enum=disable;require;verify-ca;verify-full
+	// +optional
+	SslMode string `json:"sslmode"`
 }
 
 const (

--- a/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
@@ -66,6 +66,14 @@ spec:
                 required:
                 - source
                 type: object
+              sslmode:
+                description: Defines the SSL mode used to set up a connection to the provided PostgreSQL instance
+                enum:
+                - disable
+                - require
+                - verify-ca
+                - verify-full
+                type: string
             required:
             - credentials
             type: object

--- a/pkg/clients/postgresql/postgresql.go
+++ b/pkg/clients/postgresql/postgresql.go
@@ -3,7 +3,6 @@ package postgresql
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/crossplane-contrib/provider-sql/pkg/clients/xsql"
 	"github.com/lib/pq"
@@ -30,11 +29,11 @@ type postgresDB struct {
 // New returns a new PostgreSQL database client. The default database name is
 // an empty string. The underlying pq library will default to either using the
 // value of PGDATABASE, or if unset, the hardcoded string 'postgres'.
-func New(creds map[string][]byte, database string) xsql.DB {
+// The sslmode defines the mode used to set up the connection for the provider.
+func New(creds map[string][]byte, database string, sslmode string) xsql.DB {
 	// TODO(negz): Support alternative connection secret formats?
 	endpoint := string(creds[xpv1.ResourceCredentialsSecretEndpointKey])
 	port := string(creds[xpv1.ResourceCredentialsSecretPortKey])
-	sslmode := string(creds[sslModeKey])
 
 	dsn := "postgres://" +
 		string(creds[xpv1.ResourceCredentialsSecretUserKey]) + ":" +
@@ -44,7 +43,7 @@ func New(creds map[string][]byte, database string) xsql.DB {
 		database
 
 	if sslmode != "" {
-		dsn = fmt.Sprintf("%s?sslmode=%s", dsn, sslmode)
+		dsn = dsn + "?sslmode=" + sslmode
 	}
 
 	return postgresDB{

--- a/pkg/controller/postgresql/database/reconciler.go
+++ b/pkg/controller/postgresql/database/reconciler.go
@@ -86,7 +86,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	kube  client.Client
 	usage resource.Tracker
-	newDB func(creds map[string][]byte, database string) xsql.DB
+	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -119,7 +119,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetSecret)
 	}
 
-	return &external{db: c.newDB(s.Data, "")}, nil
+	return &external{db: c.newDB(s.Data, "", pc.Spec.SslMode)}, nil
 }
 
 type external struct{ db xsql.DB }

--- a/pkg/controller/postgresql/database/reconciler_test.go
+++ b/pkg/controller/postgresql/database/reconciler_test.go
@@ -64,7 +64,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte, database string) xsql.DB
+		newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 	}
 
 	type args struct {

--- a/pkg/controller/postgresql/extension/reconciler.go
+++ b/pkg/controller/postgresql/extension/reconciler.go
@@ -76,7 +76,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	kube  client.Client
 	usage resource.Tracker
-	newDB func(creds map[string][]byte, database string) xsql.DB
+	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -112,10 +112,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	// We do not want to create an extension on the default DB
 	// if the user was expecting a database name to be resolved.
 	if cr.Spec.ForProvider.Database != nil {
-		return &external{db: c.newDB(s.Data, *cr.Spec.ForProvider.Database)}, nil
+		return &external{db: c.newDB(s.Data, *cr.Spec.ForProvider.Database, pc.Spec.SslMode)}, nil
 	}
 
-	return &external{db: c.newDB(s.Data, "")}, nil
+	return &external{db: c.newDB(s.Data, "", pc.Spec.SslMode)}, nil
 }
 
 type external struct{ db xsql.DB }

--- a/pkg/controller/postgresql/extension/reconciler_test.go
+++ b/pkg/controller/postgresql/extension/reconciler_test.go
@@ -64,7 +64,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte, database string) xsql.DB
+		newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 	}
 
 	type args struct {

--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -87,7 +87,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	kube  client.Client
 	usage resource.Tracker
-	newDB func(creds map[string][]byte, database string) xsql.DB
+	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -120,7 +120,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetSecret)
 	}
 	return &external{
-		db:   c.newDB(s.Data, ""),
+		db:   c.newDB(s.Data, "", pc.Spec.SslMode),
 		kube: c.kube,
 	}, nil
 }

--- a/pkg/controller/postgresql/grant/reconciler_test.go
+++ b/pkg/controller/postgresql/grant/reconciler_test.go
@@ -68,7 +68,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte, database string) xsql.DB
+		newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 	}
 
 	type args struct {

--- a/pkg/controller/postgresql/role/reconciler.go
+++ b/pkg/controller/postgresql/role/reconciler.go
@@ -84,7 +84,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 type connector struct {
 	kube  client.Client
 	usage resource.Tracker
-	newDB func(creds map[string][]byte, database string) xsql.DB
+	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -118,7 +118,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	}
 
 	return &external{
-		db:   c.newDB(s.Data, ""),
+		db:   c.newDB(s.Data, "", pc.Spec.SslMode),
 		kube: c.kube,
 	}, nil
 }

--- a/pkg/controller/postgresql/role/reconciler_test.go
+++ b/pkg/controller/postgresql/role/reconciler_test.go
@@ -74,7 +74,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte, database string) xsql.DB
+		newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 	}
 
 	type args struct {


### PR DESCRIPTION
Running PosgreSQL (locally on k8s) without SSL enabled is not
supported by lib/pq which has the default SSL mode on 'required'.

### Description of your changes

Added reading of sslmode from the ProviderConfig so that it's possible to divert from the default lib/pq configuration. 
The SSL mode is used to establish a connection to the managed resource and it is included in the connection secrets for created databases so that users also know changes to the sslmode.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

There are no unit tests on parsing ProviderConfig secrets. Tested this running on a local cluster in combination with Postgres in its default config from the Bitnami helm chart and not passing sslmode in the ProviderConfig.


