### PR TITLE
Add friendly error for memberOf grant

### DIFF
--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -58,6 +58,8 @@ const (
 
 	errInvalidParams = "invalid parameters for grant type %s"
 
+	errMemberOfWithDatabaseOrPrivileges = "cannot set privileges or database in the same grant as memberOf"
+
 	maxConcurrency = 5
 )
 
@@ -143,7 +145,7 @@ func identifyGrantType(gp v1alpha1.GrantParameters) (grantType, error) {
 	// then this is still a roleMember grant type.
 	if gp.MemberOfRef != nil || gp.MemberOfSelector != nil || gp.MemberOf != nil {
 		if gp.Database != nil || pc > 0 {
-			return "", errors.Errorf(errInvalidParams, roleMember)
+			return "", errors.New(errMemberOfWithDatabaseOrPrivileges)
 		}
 		return roleMember, nil
 	}


### PR DESCRIPTION
When creating a grant it was hard to understand that we needed two grants to add both global and database scoped privileges.
We stumbled on this error message, and had to read the sourcecode to understand why the grant was failing.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
