### PR TITLE
Add new postgresql resource examples to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ managed resources, this provider reconciles it's managed resources every 10 minu
 
 ## PostgreSQL
 
+### Database
+
 To create a PostgreSQL database named 'example':
 
 ```yaml
@@ -31,6 +33,80 @@ metadata:
   name: example
 spec:
   forProvider: {}
+```
+
+### Extension
+
+To create a PostgreSQL 'hstore' extension on database 'example':
+
+```yaml
+---
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: Extension
+metadata:
+  name: example
+spec:
+  forProvider:
+    extension: hstore
+    databaseRef:
+      name: example
+```
+
+### Role
+
+To create a PostgreSQL role named 'example', that allows logins:
+
+```yaml
+---
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: Role
+metadata:
+  name: example
+spec:
+  forProvider:
+    privileges:
+      login: true
+  writeConnectionSecretToRef:
+    name: example-role-secret
+    namespace: crossplane-system
+```
+
+If no password is provided in `.spec.forProvider.passwordSecretRef`, a random one will be generated.
+
+### Grant
+
+To create a PostgreSQL role membership grant between 'parent-role' and 'child-role':
+
+```yaml
+---
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: Grant
+metadata:
+  name: example-grant-role-membership
+spec:
+  forProvider:
+    roleRef:
+      name: example-role
+    memberOfRef:
+      name: parent-role
+```
+
+To create a PostgreSQL permissions grant on role 'example' and database 'example':
+
+```yaml
+---
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: Grant
+metadata:
+  name: example-grant-connect-to-role-on-database
+spec:
+  forProvider:
+    privileges:
+      - CONNECT
+    roleRef:
+      name: example
+    databaseRef:
+      name: example
 ```
 
 ## MySQL


### PR DESCRIPTION
A number of the more recently added PostgreSQL resources were missing basic examples in the README.

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
