### PR TITLE
Add dbName to provider config defaulting to postgres

### DIFF
--- a/apis/postgresql/v1alpha1/provider_types.go
+++ b/apis/postgresql/v1alpha1/provider_types.go
@@ -26,6 +26,10 @@ import (
 type ProviderConfigSpec struct {
 	// Credentials required to authenticate to this provider.
 	Credentials ProviderCredentials `json:"credentials"`
+	// Defines the database name used to set up a connection to the provided
+	// PostgreSQL instance. Same as PGDATABASE environment variable.
+	// +kubebuilder:default="postgres"
+	DBName string `json:"dbName"`
 }
 
 const (

--- a/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_providerconfigs.yaml
@@ -66,8 +66,13 @@ spec:
                 required:
                 - source
                 type: object
+              dbName:
+                default: postgres
+                description: Defines the database name used to set up a connection to the provided PostgreSQL instance. Same as PGDATABASE environment variable.
+                type: string
             required:
             - credentials
+            - dbName
             type: object
           status:
             description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.

--- a/pkg/controller/postgresql/database/reconciler.go
+++ b/pkg/controller/postgresql/database/reconciler.go
@@ -119,7 +119,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetSecret)
 	}
 
-	return &external{db: c.newDB(s.Data, "")}, nil
+	return &external{db: c.newDB(s.Data, pc.Spec.DBName)}, nil
 }
 
 type external struct{ db xsql.DB }

--- a/pkg/controller/postgresql/extension/reconciler.go
+++ b/pkg/controller/postgresql/extension/reconciler.go
@@ -115,7 +115,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return &external{db: c.newDB(s.Data, *cr.Spec.ForProvider.Database)}, nil
 	}
 
-	return &external{db: c.newDB(s.Data, "")}, nil
+	return &external{db: c.newDB(s.Data, pc.Spec.DBName)}, nil
 }
 
 type external struct{ db xsql.DB }

--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -120,7 +120,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetSecret)
 	}
 	return &external{
-		db:   c.newDB(s.Data, ""),
+		db:   c.newDB(s.Data, pc.Spec.DBName),
 		kube: c.kube,
 	}, nil
 }

--- a/pkg/controller/postgresql/role/reconciler.go
+++ b/pkg/controller/postgresql/role/reconciler.go
@@ -118,7 +118,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	}
 
 	return &external{
-		db:   c.newDB(s.Data, ""),
+		db:   c.newDB(s.Data, pc.Spec.DBName),
 		kube: c.kube,
 	}, nil
 }


### PR DESCRIPTION
### Description of your changes

This PR introduces a new config to `ProviderConfig` spec as `dbName` which defaults to `postgres`. This configuration might be introduced in different places like as a connection key or in managed resource spec but the discussion in #40 seems to have landed as `ProviderConfig` spec is the best place for this kind of configuration.

Fixes #23 as described [here](https://github.com/crossplane-contrib/provider-sql/issues/23#issuecomment-905022150). 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested against both an `AWS RDSInstance` and an `Azure PostgreSQLServer` created by Crossplane without setting dbName in ProviderConfig and relying on OpenAPI defaulting mechanism.

[contribution process]: https://git.io/fj2m9
