### PR TITLE
fix(mysql/user): correctly compare upToDate resourceOptions

### DIFF
--- a/pkg/controller/mysql/user/reconciler.go
+++ b/pkg/controller/mysql/user/reconciler.go
@@ -187,12 +187,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	username, host := mysql.SplitUserHost(meta.GetExternalName(cr))
 
 	observed := &v1alpha1.UserParameters{
-		ResourceOptions: &v1alpha1.ResourceOptions{
-			MaxQueriesPerHour:     new(int),
-			MaxUpdatesPerHour:     new(int),
-			MaxConnectionsPerHour: new(int),
-			MaxUserConnections:    new(int),
-		},
+		ResourceOptions: &v1alpha1.ResourceOptions{},
 	}
 
 	query := "SELECT " +
@@ -373,16 +368,18 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 }
 
 func upToDate(observed *v1alpha1.UserParameters, desired *v1alpha1.UserParameters) bool {
-	if *observed.ResourceOptions.MaxQueriesPerHour != *desired.ResourceOptions.MaxQueriesPerHour {
+	if observed.ResourceOptions.MaxQueriesPerHour != desired.ResourceOptions.MaxQueriesPerHour {
+		fmt.Printf("%#v\n", observed.ResourceOptions.MaxQueriesPerHour)
+		fmt.Printf("%#v\n", desired.ResourceOptions.MaxQueriesPerHour)
 		return false
 	}
-	if *observed.ResourceOptions.MaxUpdatesPerHour != *desired.ResourceOptions.MaxUpdatesPerHour {
+	if observed.ResourceOptions.MaxUpdatesPerHour != desired.ResourceOptions.MaxUpdatesPerHour {
 		return false
 	}
-	if *observed.ResourceOptions.MaxConnectionsPerHour != *desired.ResourceOptions.MaxConnectionsPerHour {
+	if observed.ResourceOptions.MaxConnectionsPerHour != desired.ResourceOptions.MaxConnectionsPerHour {
 		return false
 	}
-	if *observed.ResourceOptions.MaxUserConnections != *desired.ResourceOptions.MaxUserConnections {
+	if observed.ResourceOptions.MaxUserConnections != desired.ResourceOptions.MaxUserConnections {
 		return false
 	}
 	return true

--- a/pkg/controller/mysql/user/reconciler_test.go
+++ b/pkg/controller/mysql/user/reconciler_test.go
@@ -266,12 +266,7 @@ func TestObserve(t *testing.T) {
 				mg: &v1alpha1.User{
 					Spec: v1alpha1.UserSpec{
 						ForProvider: v1alpha1.UserParameters{
-							ResourceOptions: &v1alpha1.ResourceOptions{
-								MaxQueriesPerHour:     new(int),
-								MaxUpdatesPerHour:     new(int),
-								MaxConnectionsPerHour: new(int),
-								MaxUserConnections:    new(int),
-							},
+							ResourceOptions: &v1alpha1.ResourceOptions{},
 						},
 					},
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The pointer-compare caused a panic in my test cluster, had another look at the Postgresql
cod, there the actual values are used not the pointers to compare. Also it doesn't
initialize the integer values, so removed that too.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran `make reviewable test e2e`

[contribution process]: https://git.io/fj2m9