### PR TITLE
fix(mssql/grants): Resolve TestUpdate/Success flakyness

### DIFF
--- a/pkg/controller/mssql/grant/reconciler.go
+++ b/pkg/controller/mssql/grant/reconciler.go
@@ -19,6 +19,7 @@ package grant
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -174,6 +175,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	toGrant, toRevoke := diffPermissions(desired, observed)
 
 	if len(toRevoke) > 0 {
+		sort.Strings(toRevoke)
 		query := fmt.Sprintf("REVOKE %s FROM %s",
 			strings.Join(toRevoke, ", "), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
 		if err = c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
@@ -181,6 +183,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		}
 	}
 	if len(toGrant) > 0 {
+		sort.Strings(toGrant)
 		query := fmt.Sprintf("GRANT %s TO %s",
 			strings.Join(toGrant, ", "), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
 		if err = c.db.Exec(ctx, xsql.Query{String: query}); err != nil {


### PR DESCRIPTION
### Description of your changes
The TestUpdate/Success test in `pkg/controller/mssql/grant/reconciler_test.go` fails sometimes because the order of grants isn't guaranteed. This makes the condition in https://github.com/crossplane-contrib/provider-sql/blob/master/pkg/controller/mssql/grant/reconciler_test.go#L528  `false` occationally. Which for instance make the CI run in https://github.com/crossplane-contrib/provider-sql/pull/69 fail.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Ran the following before and after the fix:
```
pwd
provider-sql/pkg/controller/mssql/grant
while true; do go test -run TestUpdate/Success; done                                                           
PASS                                                                                                                                                      
ok      github.com/crossplane-contrib/provider-sql/pkg/controller/mssql/grant   0.014s
PASS                                                                                                                                                      
ok      github.com/crossplane-contrib/provider-sql/pkg/controller/mssql/grant   0.011s
PASS                                                                                                                                                      
ok      github.com/crossplane-contrib/provider-sql/pkg/controller/mssql/grant   0.012s
--- FAIL: TestUpdate (0.00s)                                                                                                                              
    --- FAIL: TestUpdate/Success (0.00s)                        
        reconciler_test.go:560:                                                                                                                           
            No error should be returned when we update a grant
            e.Create(...): -want error, +got error:                                                                                                       
              interface{}(               
            +   e"cannot grant: boom",                                                                                                                    
              )                 
                                                                                                                                                          
FAIL                                                                                                                                  
exit status 1                                                                                                                                             
FAIL    github.com/crossplane-contrib/provider-sql/pkg/controller/mssql/grant   0.011s
```
After the fix I could never get it to fail.


