### PR TITLE
test(mysql/user): fail with panic, resourceOptions are optional

### DIFF
--- a/pkg/controller/mysql/user/reconciler.go
+++ b/pkg/controller/mysql/user/reconciler.go
@@ -368,9 +368,11 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 }
 
 func upToDate(observed *v1alpha1.UserParameters, desired *v1alpha1.UserParameters) bool {
+	if desired.ResourceOptions == nil {
+		// Return true if there are no desired ResourceOptions
+		return true
+	}
 	if observed.ResourceOptions.MaxQueriesPerHour != desired.ResourceOptions.MaxQueriesPerHour {
-		fmt.Printf("%#v\n", observed.ResourceOptions.MaxQueriesPerHour)
-		fmt.Printf("%#v\n", desired.ResourceOptions.MaxQueriesPerHour)
 		return false
 	}
 	if observed.ResourceOptions.MaxUpdatesPerHour != desired.ResourceOptions.MaxUpdatesPerHour {

--- a/pkg/controller/mysql/user/reconciler_test.go
+++ b/pkg/controller/mysql/user/reconciler_test.go
@@ -226,14 +226,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.User{
 					Spec: v1alpha1.UserSpec{
-						ForProvider: v1alpha1.UserParameters{
-							ResourceOptions: &v1alpha1.ResourceOptions{
-								MaxQueriesPerHour:     new(int),
-								MaxUpdatesPerHour:     new(int),
-								MaxConnectionsPerHour: new(int),
-								MaxUserConnections:    new(int),
-							},
-						},
+						ForProvider: v1alpha1.UserParameters{},
 					},
 				},
 			},
@@ -265,9 +258,7 @@ func TestObserve(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.User{
 					Spec: v1alpha1.UserSpec{
-						ForProvider: v1alpha1.UserParameters{
-							ResourceOptions: &v1alpha1.ResourceOptions{},
-						},
+						ForProvider: v1alpha1.UserParameters{},
 					},
 				},
 			},
@@ -305,12 +296,6 @@ func TestObserve(t *testing.T) {
 									Name: "example",
 								},
 								Key: "password",
-							},
-							ResourceOptions: &v1alpha1.ResourceOptions{
-								MaxQueriesPerHour:     new(int),
-								MaxUpdatesPerHour:     new(int),
-								MaxConnectionsPerHour: new(int),
-								MaxUserConnections:    new(int),
 							},
 						},
 						ResourceSpec: xpv1.ResourceSpec{
@@ -411,14 +396,7 @@ func TestCreate(t *testing.T) {
 						},
 					},
 					Spec: v1alpha1.UserSpec{
-						ForProvider: v1alpha1.UserParameters{
-							ResourceOptions: &v1alpha1.ResourceOptions{
-								MaxQueriesPerHour:     new(int),
-								MaxUpdatesPerHour:     new(int),
-								MaxConnectionsPerHour: new(int),
-								MaxUserConnections:    new(int),
-							},
-						},
+						ForProvider: v1alpha1.UserParameters{},
 					},
 				},
 			},
@@ -860,14 +838,7 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.User{
 					Spec: v1alpha1.UserSpec{
-						ForProvider: v1alpha1.UserParameters{
-							ResourceOptions: &v1alpha1.ResourceOptions{
-								MaxQueriesPerHour:     new(int),
-								MaxUpdatesPerHour:     new(int),
-								MaxConnectionsPerHour: new(int),
-								MaxUserConnections:    new(int),
-							},
-						},
+						ForProvider: v1alpha1.UserParameters{},
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #74

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Initial commit updates the test: remove the `ResourceOptions` from the object as it is
optional, this should make the unit tests fail with a panic just as observed in #74.

Second commit checks whether the `desired.ResourceOptions` is actually set, if not it
returns as being up-to-date as we accept the defaults. This should resolve the test failures.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9