### PR TITLE
Mysql default port

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -39,7 +39,7 @@ func main() {
 		app            = kingpin.New(filepath.Base(os.Args[0]), "SQL support for Crossplane.").DefaultEnvars()
 		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncPeriod     = app.Flag("sync", "Controller manager sync period such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
-		leaderElection = app.Flag("leader-election", "Use leader election for the conroller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
+		leaderElection = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 

--- a/pkg/clients/mysql/mysql.go
+++ b/pkg/clients/mysql/mysql.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	errNotSupported = "%s not supported by mysql client"
+	errNotSupported  = "%s not supported by mysql client"
+	defaultMySQLPort = "3306"
 )
 
 type mySQLDB struct {
@@ -28,6 +29,9 @@ func New(creds map[string][]byte) xsql.DB {
 	// TODO(negz): Support alternative connection secret formats?
 	endpoint := string(creds[xpv1.ResourceCredentialsSecretEndpointKey])
 	port := string(creds[xpv1.ResourceCredentialsSecretPortKey])
+	if port == "" {
+		port = defaultMySQLPort
+	}
 	return mySQLDB{
 		dsn: fmt.Sprintf("%s:%s@tcp(%s:%s)/",
 			creds[xpv1.ResourceCredentialsSecretUserKey],


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

When connection secret doesn't contain `port`, this change assumes default port for MySQL, 3306.

This is needed because provider-aws doesn't write port (by default) to the connection secret for Aurora DB cluster. Provider-sql shouldn't accept the empty string as it is an invalid value for port, and assume that a missing value should default to the standard port.

Fixes #76

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[Testing incomplete]
I ran `make run` locally, which caused a local reconciler to run in parallel with the one in the kubernetes cluster.

When describing the `user.mysql` on the kubernetes cluster, I see (messages only, for readability):

```
cannot select user: dial tcp 10.0.x.x:3306: i/o timeout         # local, patched reconciler
cannot select user: dial tcp 10.0.x.x:0: i/o timeout            # reconciler in the cluster
```

The change sets the port correctly. The connection to db_host:3306 is open, so I would expect that the user is created. The problem seem not to be related to my change, but I would need some assistance in figuring this out. The debug output contains (newlines added manually):

```
2022-04-05T23:46:44.471+0100    DEBUG   provider-sql    Cannot observe external resource
{
"controller": "managed/user.mysql.sql.crossplane.io",
"request": "/cluster-test-user",
"uid": "...",
"version": "...",
"external-name": "cluster-test-user",
"error": "cannot select user: dial tcp 10.0.x.x:3306: i/o timeout",
"errorVerbose": "dial tcp 10.0.x.2x:3306: i/o timeout
      cannot select user
      github.com/crossplane-contrib/provider-sql/pkg/controller/mysql/user.(*external).Observe
          /workdir/opensource/provider-sql/pkg/controller/mysql/user/reconciler.go:216 ..."
```

I checked that the port 3306 is part of `c.db` in `Observe`. I suspect that the issue with connection comes from the interaction of the two reconcilers.


[contribution process]: https://git.io/fj2m9
