### PR TITLE
Support mysql-grants by table

### DIFF
--- a/apis/mysql/v1alpha1/grant_types.go
+++ b/apis/mysql/v1alpha1/grant_types.go
@@ -75,6 +75,10 @@ type GrantParameters struct {
 	// +optional
 	UserSelector *xpv1.Selector `json:"userSelector,omitempty"`
 
+	// Tables this grant is for.
+	// +optional
+	Table *string `json:"table,omitempty" default:"*"`
+
 	// Database this grant is for.
 	// +optional
 	Database *string `json:"database,omitempty"`

--- a/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -199,6 +199,11 @@ func (in *GrantParameters) DeepCopyInto(out *GrantParameters) {
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Table != nil {
+		in, out := &in.Table, &out.Table
+		*out = new(string)
+		**out = **in
+	}
 	if in.Database != nil {
 		in, out := &in.Database, &out.Database
 		*out = new(string)

--- a/examples/mysql/grant_table.yaml
+++ b/examples/mysql/grant_table.yaml
@@ -1,0 +1,15 @@
+apiVersion: mysql.sql.crossplane.io/v1alpha1
+kind: Grant
+metadata:
+  name: example-grant-table
+spec:
+  forProvider:
+    privileges:
+      - DROP
+      - INSERT
+      - SELECT
+    table: example-table
+    userRef:
+      name: example-user
+    databaseRef:
+      name: example-db

--- a/package/crds/mysql.sql.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.crossplane.io_grants.yaml
@@ -96,6 +96,9 @@ spec:
                       type: string
                     minItems: 1
                     type: array
+                  table:
+                    description: Tables this grant is for.
+                    type: string
                   user:
                     description: User this grant is for.
                     type: string

--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -216,23 +216,8 @@ func (c *external) getPrivileges(ctx context.Context, username, dbname string, t
 		}
 		p := parseGrant(grant, dbname, table)
 
-		/*
-			if p != nil && privileges != nil {
-				// Found more than one grant for this user/DB pair.
-				// This probably shouldn't happen because MySQL groups privileges
-				// for the same user/DB pair in a single grant.
-				// In any case we want to update and ensure the privileges of our grant.
-				return nil, &managed.ExternalObservation{
-					ResourceExists:   true,
-					ResourceUpToDate: false,
-				}, nil
-			}
-			privileges = p
-		*/
-
-		// NOTE: this breaks the previous "safety"-switch for the same user/DB pair in a single grant
-		// but when managing tables in grants we need to break as soon as we found something
 		if p != nil {
+			// found the grant we were looking for
 			privileges = p
 			break
 		}

--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -61,7 +61,7 @@ const (
 )
 
 var (
-	grantRegex = regexp.MustCompile("^GRANT (.+) ON `(.+)`\\.\\* TO .+")
+	grantRegex = regexp.MustCompile("^GRANT (.+) ON `(.+)`\\.(.+) TO .+")
 )
 
 // Setup adds a controller that reconciles Grant managed resources.
@@ -141,8 +141,9 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	username := *cr.Spec.ForProvider.User
 	dbname := *cr.Spec.ForProvider.Database
+	table := defaultTable(cr.Spec.ForProvider.Table)
 
-	privileges, result, err := c.getPrivileges(ctx, username, dbname)
+	privileges, result, err := c.getPrivileges(ctx, username, dbname, table)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -165,6 +166,13 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}, nil
 }
 
+func defaultTable(table *string) string {
+	if !(table == nil) {
+		return mysql.QuoteIdentifier(*table)
+	}
+	return "*"
+}
+
 func privilegesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -183,15 +191,15 @@ func privilegesEqual(a, b []string) bool {
 	return true
 }
 
-func parseGrant(grant, dbname string) (privileges []string) {
+func parseGrant(grant, dbname string, table string) (privileges []string) {
 	matches := grantRegex.FindStringSubmatch(grant)
-	if len(matches) == 3 && matches[2] == dbname {
+	if len(matches) == 4 && matches[2] == dbname && matches[3] == table {
 		return strings.Split(matches[1], ", ")
 	}
 	return nil
 }
 
-func (c *external) getPrivileges(ctx context.Context, username, dbname string) ([]string, *managed.ExternalObservation, error) {
+func (c *external) getPrivileges(ctx context.Context, username, dbname string, table string) ([]string, *managed.ExternalObservation, error) {
 	username, host := mysql.SplitUserHost(username)
 	query := fmt.Sprintf("SHOW GRANTS FOR %s@%s", mysql.QuoteValue(username), mysql.QuoteValue(host))
 	rows, err := c.db.Query(ctx, xsql.Query{String: query})
@@ -206,19 +214,30 @@ func (c *external) getPrivileges(ctx context.Context, username, dbname string) (
 		if err := rows.Scan(&grant); err != nil {
 			return nil, nil, errors.Wrap(err, errCurrentGrant)
 		}
-		p := parseGrant(grant, dbname)
-		if p != nil && privileges != nil {
-			// Found more than one grant for this user/DB pair.
-			// This probably shouldn't happen because MySQL groups privileges
-			// for the same user/DB pair in a single grant.
-			// In any case we want to update and ensure the privileges of our grant.
-			return nil, &managed.ExternalObservation{
-				ResourceExists:   true,
-				ResourceUpToDate: false,
-			}, nil
+		p := parseGrant(grant, dbname, table)
+
+		/*
+			if p != nil && privileges != nil {
+				// Found more than one grant for this user/DB pair.
+				// This probably shouldn't happen because MySQL groups privileges
+				// for the same user/DB pair in a single grant.
+				// In any case we want to update and ensure the privileges of our grant.
+				return nil, &managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				}, nil
+			}
+			privileges = p
+		*/
+
+		// NOTE: this breaks the previous "safety"-switch for the same user/DB pair in a single grant
+		// but when managing tables in grants we need to break as soon as we found something
+		if p != nil {
+			privileges = p
+			break
 		}
-		privileges = p
 	}
+
 	if err := rows.Err(); err != nil {
 		var myErr *mysqldriver.MySQLError
 		if errors.As(err, &myErr) && myErr.Number == errCodeNoSuchGrant {
@@ -241,10 +260,11 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	username := *cr.Spec.ForProvider.User
 	dbname := *cr.Spec.ForProvider.Database
+	table := defaultTable(cr.Spec.ForProvider.Table)
 
 	privileges := strings.Join(cr.Spec.ForProvider.Privileges.ToStringSlice(), ", ")
 
-	query := createGrantQuery(privileges, dbname, username)
+	query := createGrantQuery(privileges, dbname, username, table)
 	if err := c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateGrant)
 	}
@@ -260,6 +280,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	username := *cr.Spec.ForProvider.User
 	dbname := *cr.Spec.ForProvider.Database
+	table := defaultTable(cr.Spec.ForProvider.Table)
 
 	privileges := strings.Join(cr.Spec.ForProvider.Privileges.ToStringSlice(), ", ")
 	username, host := mysql.SplitUserHost(username)
@@ -269,8 +290,9 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	// until the privileges are granted again.
 	// Using a transaction is unfortunately not possible because a GRANT triggers
 	// an implicit commit: https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
-	query := fmt.Sprintf("REVOKE ALL ON %s.* FROM %s@%s",
+	query := fmt.Sprintf("REVOKE ALL ON %s.%s FROM %s@%s",
 		mysql.QuoteIdentifier(dbname),
+		table,
 		mysql.QuoteValue(username),
 		mysql.QuoteValue(host),
 	)
@@ -278,7 +300,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.Wrap(err, errRevokeGrant)
 	}
 
-	query = createGrantQuery(privileges, dbname, username)
+	query = createGrantQuery(privileges, dbname, username, table)
 	if err := c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 		return managed.ExternalUpdate{}, err
 	}
@@ -286,14 +308,17 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	return managed.ExternalUpdate{}, errors.Wrap(err, errFlushPriv)
 }
 
-func createGrantQuery(privileges, dbname, username string) string {
+func createGrantQuery(privileges, dbname, username string, table string) string {
 	username, host := mysql.SplitUserHost(username)
-	return fmt.Sprintf("GRANT %s ON %s.* TO %s@%s",
+	result := fmt.Sprintf("GRANT %s ON %s.%s TO %s@%s",
 		privileges,
 		mysql.QuoteIdentifier(dbname),
+		table,
 		mysql.QuoteValue(username),
 		mysql.QuoteValue(host),
 	)
+
+	return result
 }
 
 func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
@@ -304,16 +329,19 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 	username := *cr.Spec.ForProvider.User
 	dbname := *cr.Spec.ForProvider.Database
+	table := defaultTable(cr.Spec.ForProvider.Table)
 
 	privileges := strings.Join(cr.Spec.ForProvider.Privileges.ToStringSlice(), ", ")
 	username, host := mysql.SplitUserHost(username)
 
-	query := fmt.Sprintf("REVOKE %s ON %s.* FROM %s@%s",
+	query := fmt.Sprintf("REVOKE %s ON %s.%s FROM %s@%s",
 		privileges,
 		mysql.QuoteIdentifier(dbname),
+		table,
 		mysql.QuoteValue(username),
 		mysql.QuoteValue(host),
 	)
+
 	if err := c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 		return errors.Wrap(err, errRevokeGrant)
 	}

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -376,7 +376,7 @@ func TestObserve(t *testing.T) {
 			want: want{
 				o: managed.ExternalObservation{
 					ResourceExists:   true,
-					ResourceUpToDate: false,
+					ResourceUpToDate: true,
 				},
 				err: nil,
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Introduces support for grants by individual tables in mysql

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Code was tested in local-setup with kind-cluster created with `make dev`. A local mysql-instance was connected to the provider and manual verification has been done. 
Unit-tests were part of standard-procedure.
I did *not* adjust e2e. I ran these but i think i'm missing something because it's failing with ```Error from server (BadRequest): container "provider-sql" in pod "provider-sql-provider-sql-ffb4544-6kv29" is waiting to start: ErrImageNeverPull```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
