### PR TITLE
Handle `*` dbname without throwing error

### DIFF
--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -287,10 +287,14 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 }
 
 func createGrantQuery(privileges, dbname, username string) string {
+	if dbname != "*" {
+		dbname := mysql.QuoteIdentifier(dbname)
+	}
+
 	username, host := mysql.SplitUserHost(username)
 	return fmt.Sprintf("GRANT %s ON %s.* TO %s@%s",
 		privileges,
-		mysql.QuoteIdentifier(dbname),
+		dbname,
 		mysql.QuoteValue(username),
 		mysql.QuoteValue(host),
 	)

--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -307,10 +307,14 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 	privileges := strings.Join(cr.Spec.ForProvider.Privileges.ToStringSlice(), ", ")
 	username, host := mysql.SplitUserHost(username)
+	
+	if dbname != "*" {
+		dbname := mysql.QuoteIdentifier(dbname)
+	}
 
 	query := fmt.Sprintf("REVOKE %s ON %s.* FROM %s@%s",
 		privileges,
-		mysql.QuoteIdentifier(dbname),
+		dbname,
 		mysql.QuoteValue(username),
 		mysql.QuoteValue(host),
 	)

--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -292,7 +292,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 func createGrantQuery(privileges, dbname, username string) string {
 	if dbname != "*" {
-		dbname := mysql.QuoteIdentifier(dbname)
+		dbname = mysql.QuoteIdentifier(dbname)
 	}
 
 	username, host := mysql.SplitUserHost(username)
@@ -315,9 +315,9 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 	privileges := strings.Join(cr.Spec.ForProvider.Privileges.ToStringSlice(), ", ")
 	username, host := mysql.SplitUserHost(username)
-	
+
 	if dbname != "*" {
-		dbname := mysql.QuoteIdentifier(dbname)
+		dbname = mysql.QuoteIdentifier(dbname)
 	}
 
 	query := fmt.Sprintf("REVOKE %s ON %s.* FROM %s@%s",


### PR DESCRIPTION
### Description of your changes

Currently, if you pass dbname `*` you get an error:

```
ERROR 1221 (HY000): Incorrect usage of DB GRANT and GLOBAL PRIVILEGES
```

This checks if the value you pass is exactly `*`, and if it is, leaves it alone (to be not quoted by mysql), and keeps quoting the remaining parameters passed.

Fixes #79 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I am new to go, and not entirely sure how to go about testing this properly.

I have tested the resultant SQL manually.

The "old" version with the quoted `*` throws the error, and the version without it quoted does not throw it.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
