### PR TITLE
postgresql - add support for "ALL" Privileges

### DIFF
--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -191,6 +191,13 @@ func selectGrantQuery(gp v1alpha1.GrantParameters, q *xsql.Query) error {
 		return nil
 	case roleDatabase:
 		gro := gp.WithOption != nil && *gp.WithOption == v1alpha1.GrantOptionGrant
+
+		// Resolve privilege ALL shorthand to CTc
+		// https://www.postgresql.org/docs/12/ddl-priv.html#PRIVILEGES-SUMMARY-TABLE
+		if len(gp.Privileges) == 1 && gp.Privileges[0] == "ALL" {
+			gp.Privileges = v1alpha1.GrantPrivileges{"CREATE", "TEMPORARY", "CONNECT"}
+		}
+
 		sp := gp.Privileges.ToStringSlice()
 		// Join grantee. Filter by database name and grantee name.
 		// Finally, perform a permission comparison against expected


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #92

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manually made sure a Grant with ALL privileges has the desired effect on a database and becomes "ready"
Example MRs:

```
apiVersion: postgresql.sql.crossplane.io/v1alpha1
kind: Database
metadata:
  name: example-db
spec:
  forProvider: {}
  providerConfigRef:
    name: postgres-example
---
apiVersion: postgresql.sql.crossplane.io/v1alpha1
kind: Role
metadata:
  name: example-role2
spec:
  forProvider:
    privileges:
      login: true
  writeConnectionSecretToRef:
    name: example-role2-secret
    namespace: default
  providerConfigRef:
    name: postgres-example
---
apiVersion: postgresql.sql.crossplane.io/v1alpha1
kind: Grant
metadata:
  name: example-role2-on-example-db
spec:
  forProvider:
    databaseRef:
      name: example-db
    roleRef:
      name: example-role
    privileges:
      - ALL
  providerConfigRef:
    name: postgres-example
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
