### PR TITLE
Fixed database by passing a default value

### DIFF
--- a/apis/mysql/v1alpha1/grant_types.go
+++ b/apis/mysql/v1alpha1/grant_types.go
@@ -75,13 +75,13 @@ type GrantParameters struct {
 	// +optional
 	UserSelector *xpv1.Selector `json:"userSelector,omitempty"`
 
-	// Tables this grant is for.
+	// Tables this grant is for, default *.
 	// +optional
 	Table *string `json:"table,omitempty" default:"*"`
 
-	// Database this grant is for.
+	// Database this grant is for, default *.
 	// +optional
-	Database *string `json:"database,omitempty"`
+	Database *string `json:"database,omitempty" default:"*"`
 
 	// DatabaseRef references the database object this grant it for.
 	// +immutable

--- a/package/crds/mysql.sql.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.crossplane.io_grants.yaml
@@ -72,7 +72,7 @@ spec:
                   instance.
                 properties:
                   database:
-                    description: Database this grant is for.
+                    description: Database this grant is for, default *.
                     type: string
                   databaseRef:
                     description: DatabaseRef references the database object this grant
@@ -159,7 +159,7 @@ spec:
                     minItems: 1
                     type: array
                   table:
-                    description: Tables this grant is for.
+                    description: Tables this grant is for, default *.
                     type: string
                   user:
                     description: User this grant is for.

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -381,6 +381,36 @@ func TestObserve(t *testing.T) {
 				err: nil,
 			},
 		},
+		"SuccessGrantNoDatabaseNoTable": {
+			reason: "We should return no error if no database and table were provided",
+			fields: fields{
+				db: mockDB{
+					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
+						return mockRowsToSQLRows(
+							sqlmock.NewRows([]string{"Grants"}).
+								AddRow("GRANT CREATE, DROP ON *.* TO 'success-user'@%"),
+						), nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Grant{
+					Spec: v1alpha1.GrantSpec{
+						ForProvider: v1alpha1.GrantParameters{
+							User:       pointer.StringPtr("success-user"),
+							Privileges: v1alpha1.GrantPrivileges{"DROP", "CREATE"},
+						},
+					},
+				},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
 		"SuccessGrantWithTables": {
 			reason: "We should see the grants in sync when using a table",
 			fields: fields{


### PR DESCRIPTION
### Description of your changes
Since the docs says the database is optional, I made it in the code to option, because actually if you don't pass a value this following error occurs:
```
Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
...
/home/runner/work/provider-sql/provider-sql/pkg/controller/mysql/grant/reconciler.go:143 +0x98
```
This also will fix #79 and #84 
Also the documentation was updated to reflect that

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
I am not a go guys but when running the `make reviewable` I got this error:
```
Can't run linter unused: buildir: failed to load package goarch: could not load export data: cannot import "internal/goarch" (unknown iexport format version 2), export data is newer version - update tool
ERRO Running error: buildir: failed to load package goarch: could not load export data: cannot import "internal/goarch" (unknown iexport format version 2), export data is newer version - update tool
```
I installed go1.17.11 as is stated in the docs and go1.13.15 as is stated in `go.mod`

### How has this code been tested

[contribution process]: https://git.io/fj2m9

### Update
1. The problem was that I was just aliasing the go1.17.11 to go and that does not work, you really need to update your PATH variable

