### PR TITLE
bugfix(roles.postgresql): Fix panic when taking ownership of existing role

### DIFF
--- a/pkg/controller/postgresql/role/reconciler.go
+++ b/pkg/controller/postgresql/role/reconciler.go
@@ -373,7 +373,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	// Checks if current role configuration parameters differs from desired state.
 	// If difference, reset all parameters and apply desired parameters in a transaction
-	if !cmp.Equal(cr.Status.AtProvider.ConfigurationParameters, cr.Spec.ForProvider.ConfigurationParameters,
+	if cr.Spec.ForProvider.ConfigurationParameters != nil && !cmp.Equal(cr.Status.AtProvider.ConfigurationParameters, cr.Spec.ForProvider.ConfigurationParameters,
 		cmpopts.SortSlices(func(o, d v1alpha1.RoleConfigurationParameter) bool { return o.Name < d.Name })) {
 		q := make([]xsql.Query, 0)
 		q = append(q, xsql.Query{


### PR DESCRIPTION
### Description of your changes
Checks that ConfigurationParamters isn't nil before comparing.

Fixes #99

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
It has been tested running out of cluster