### PR TITLE
no need to escape the mysql password

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -186,7 +186,7 @@ mariadb_root_pw=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
 "${HELM3}" repo add bitnami https://charts.bitnami.com/bitnami
 
 "${HELM3}" install mariadb bitnami/mariadb \
-    --version 9.0.1 \
+    --version 11.3.3 \
     --set auth.rootPassword="${mariadb_root_pw}" \
     --wait
 

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -186,7 +186,7 @@ mariadb_root_pw=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
 "${HELM3}" repo add bitnami https://charts.bitnami.com/bitnami
 
 "${HELM3}" install mariadb bitnami/mariadb \
-    --version 11.3.3 \
+    --version 9.0.1 \
     --set auth.rootPassword="${mariadb_root_pw}" \
     --wait
 

--- a/pkg/clients/mysql/mysql.go
+++ b/pkg/clients/mysql/mysql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/crossplane-contrib/provider-sql/pkg/clients/xsql"

--- a/pkg/clients/mysql/mysql.go
+++ b/pkg/clients/mysql/mysql.go
@@ -51,7 +51,6 @@ func DSN(username, password, endpoint, port, tls string) string {
 	// Use net/url UserPassword to encode the username and password
 	// This will ensure that any special characters in the username or password
 	// are percent-encoded for use in the user info portion of the DSN URL
-	userInfo := url.UserPassword(username, password)
 	return fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
 		username,
 		password,

--- a/pkg/clients/mysql/mysql.go
+++ b/pkg/clients/mysql/mysql.go
@@ -52,8 +52,9 @@ func DSN(username, password, endpoint, port, tls string) string {
 	// This will ensure that any special characters in the username or password
 	// are percent-encoded for use in the user info portion of the DSN URL
 	userInfo := url.UserPassword(username, password)
-	return fmt.Sprintf("%s@tcp(%s:%s)/?tls=%s",
-		userInfo,
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
+		username,
+		password,
 		endpoint,
 		port,
 		tls)

--- a/pkg/clients/mysql/mysql_test.go
+++ b/pkg/clients/mysql/mysql_test.go
@@ -10,12 +10,11 @@ func TestDSNURLEscaping(t *testing.T) {
 	port := "3306"
 	user := "username"
 	rawPass := "password^"
-	encPass := "password%5E"
 	tls := "true"
 	dsn := DSN(user, rawPass, endpoint, port, tls)
 	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
 		user,
-		encPass,
+		rawPass,
 		endpoint,
 		port,
 		tls) {


### PR DESCRIPTION
See https://github.com/crossplane-contrib/provider-sql/issues/98

Signed-off-by: Craig Skinfill <craig.skinfill@gmail.com>

### Description of your changes
Removes the URL escaping for the mysql password, based on https://github.com/go-sql-driver/mysql#password

Fixes #98 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.