### PR TITLE
Use matching database and providerconfig in postgresql examples

### DIFF
--- a/examples/postgresql/extension.yaml
+++ b/examples/postgresql/extension.yaml
@@ -7,9 +7,9 @@ spec:
     extension: hstore
     version: "1.4"
     databaseRef:
-      name: testdb
+      name: example
   providerConfigRef:
-    name: provider-config-name
+    name: default
 ---
 apiVersion: postgresql.sql.crossplane.io/v1alpha1
 kind: Extension
@@ -20,6 +20,6 @@ spec:
     extension: ltree
     version: "1.1"
     databaseRef:
-      name: testdb
+      name: example
   providerConfigRef:
-    name: provider-config-name
+    name: default


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The providerconfig and database names for extensions did not refer to working objects.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`kubectl apply -f examples/postgresql/`
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
