### PR TITLE
Add WithPollInterval to postgresql/extension

### DIFF
--- a/pkg/controller/postgresql/extension/reconciler.go
+++ b/pkg/controller/postgresql/extension/reconciler.go
@@ -19,6 +19,7 @@ package extension
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
@@ -63,6 +64,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 		resource.ManagedKind(v1alpha1.ExtensionGroupVersionKind),
 		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), usage: t, newDB: postgresql.New}),
 		managed.WithLogger(l.WithValues("controller", name)),
+		managed.WithPollInterval(10*time.Minute),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
 
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION

### Description of your changes

All other controllers use WithPollInterval, we've noticed bursts of
concurrent requests every minute from and this seems to be the source.

Use the same hard-coded 10 minute interval as the other controllers. We
can improve this further after upgrading provider-runtime in a subsequent PR.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Run in kind cluster

[contribution process]: https://git.io/fj2m9
