### PR TITLE
Fix Grant revocation

### DIFF
--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -328,6 +328,11 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	)
 
 	if err := c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
+		var myErr *mysqldriver.MySQLError
+		if errors.As(err, &myErr) && myErr.Number == errCodeNoSuchGrant {
+			//MySQL automatically deletes related grants if the user has been deleted
+			return nil
+		}
 		return errors.Wrap(err, errRevokeGrant)
 	}
 	err := c.db.Exec(ctx, xsql.Query{String: "FLUSH PRIVILEGES"})

--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -330,7 +330,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	if err := c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 		var myErr *mysqldriver.MySQLError
 		if errors.As(err, &myErr) && myErr.Number == errCodeNoSuchGrant {
-			//MySQL automatically deletes related grants if the user has been deleted
+			// MySQL automatically deletes related grants if the user has been deleted
 			return nil
 		}
 		return errors.Wrap(err, errRevokeGrant)

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -718,6 +718,27 @@ func TestDelete(t *testing.T) {
 			},
 			want: nil,
 		},
+		"SuccessGrantGone": {
+			reason: "No error should be returned if the grant is already revoked",
+			args: args{
+				mg: &v1alpha1.Grant{
+					Spec: v1alpha1.GrantSpec{
+						ForProvider: v1alpha1.GrantParameters{
+							Database: pointer.StringPtr("test-example"),
+							User:     pointer.StringPtr("test-example"),
+						},
+					},
+				},
+			},
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return &mysql.MySQLError{Number: errCodeNoSuchGrant}
+					},
+				},
+			},
+			want: nil,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
If the grant is already gone when the reconciler tries to revoke it, 
it should mark the resource as successfully removed, not error.

MySQL 8.x+ supports
`REVOKE %s IF EXISTS ON %s.%s FROM %s@%s IGNORE UNKNOWN USER` 
to avoid an error (which would be a cleaner solution IMO), 
but this will only be possible when dropping support for earlier versions.

### Description of your changes

Checks the actual mysql error code that is returned when the grant
revocation SQL errors; if the code states that the grant does not exist, 
it returns `nil` for successful removal of the grant.

Basically uses the same code as  https://github.com/crossplane-contrib/provider-sql/blob/ed6c55ce4798967e7652a4cce9f844b99ac1bbb7/pkg/controller/mysql/grant/reconciler.go#L227-L231

Fixes  #47

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Added unit test for this case to `grants/reconciler_test.go` 

[contribution process]: https://git.io/fj2m9
