### PR TITLE
Fix mysql provider config spec.tls kubebuilder validation enum

### DIFF
--- a/apis/mysql/v1alpha1/provider_types.go
+++ b/apis/mysql/v1alpha1/provider_types.go
@@ -31,7 +31,7 @@ type ProviderConfigSpec struct {
 	// or use preferred to use TLS only when advertised by the server. This is similar
 	// to skip-verify, but additionally allows a fallback to a connection which is
 	// not encrypted. Neither skip-verify nor preferred add any reliable security.
-	// +kubebuilder:validation:Enum=true;skip-verify;preferred
+	// +kubebuilder:validation:Enum="true";skip-verify;preferred
 	// +optional
 	TLS *string `json:"tls"`
 }

--- a/package/crds/mysql.sql.crossplane.io_providerconfigs.yaml
+++ b/package/crds/mysql.sql.crossplane.io_providerconfigs.yaml
@@ -81,7 +81,7 @@ spec:
                   allows a fallback to a connection which is not encrypted. Neither
                   skip-verify nor preferred add any reliable security.
                 enum:
-                - true
+                - "true"
                 - skip-verify
                 - preferred
                 type: string


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes [#137](https://github.com/crossplane-contrib/provider-sql/issues/137)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Since the current unit tests do not setup a webhook server it kinda hard to add an automatic test for this.
Tested manually with kubectl and a local kind k8s cluster
```yaml
apiVersion: mysql.sql.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: MySQLConnectionSecret
    connectionSecretRef:
      namespace: default
      name: db-conn
  # tls one of preferred(default), skip-verify, or true
  tls: true
```
```bash
> kubectl apply -f /home/alejandro/Documents/operators/crossplane/provider-sql/examples/mysql/config.yaml
The ProviderConfig "default2" is invalid: 
* spec.tls: Invalid value: "boolean": spec.tls in body must be of type string: "boolean"
* spec.tls: Unsupported value: true: supported values: "true", "skip-verify", "preferred"
```
```yaml
apiVersion: mysql.sql.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: MySQLConnectionSecret
    connectionSecretRef:
      namespace: default
      name: db-conn
  # tls one of preferred(default), skip-verify, or true
  tls: "true"
```
```bash
kubectl apply -f /home/alejandro/Documents/operators/crossplane/provider-sql/examples/mysql/config.yaml
providerconfig.mysql.sql.crossplane.io/default2 created
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
