### PR TITLE
Fix/consolidate unit tests for two PRs

### DIFF
--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -194,14 +194,22 @@ func (c *external) getPrivileges(ctx context.Context, username, dbname string, t
 		return nil, nil, errors.Wrap(err, errCurrentGrant)
 	}
 
-	// In mysql when all grants are revoked from user, it still grants usage (meaning no privileges) on *.*
-	// So the grant can be considered as non existent, just like when privileges slice is nil/empty
+	// In mysql when all grants are revoked from user, it still grants usage (meaning no
+	// privileges) on *.* So the grant can be considered as non existent, just like when
+	// privileges slice is nil/empty
 	// https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_usage
-	if privileges == nil || privilegesEqual(privileges, []string{"USAGE"}) {
+	var ret []string
+	for _, p := range privileges {
+		if p != "USAGE" {
+			ret = append(ret, p)
+		}
+	}
+
+	if ret == nil {
 		return nil, &managed.ExternalObservation{ResourceExists: false}, nil
 	}
 
-	return privileges, nil, nil
+	return ret, nil, nil
 }
 
 func (c *external) parseGrantRows(ctx context.Context, username string, host string, dbname string, table string) ([]string, error) {

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -379,7 +379,8 @@ func TestObserve(t *testing.T) {
 					ResourceExists:   true,
 					ResourceUpToDate: false,
 				},
-				err: nil,
+				observedPrivileges: []string{"INSERT"},
+				err:                nil,
 			},
 		},
 		"SuccessDiffGrantUsage": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

These two PRs changed unit tests and functionality for mysql/grants
- https://github.com/crossplane-contrib/provider-sql/pull/134
- https://github.com/crossplane-contrib/provider-sql/pull/136

Breaking unit tests on master, this PR attempts to fix it.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make reviewable`

[contribution process]: https://git.io/fj2m9