### PR TITLE
postgres: Expand grant privileges where required

### DIFF
--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -191,7 +191,9 @@ func selectGrantQuery(gp v1alpha1.GrantParameters, q *xsql.Query) error {
 		return nil
 	case roleDatabase:
 		gro := gp.WithOption != nil && *gp.WithOption == v1alpha1.GrantOptionGrant
-		sp := gp.Privileges.ToStringSlice()
+
+		ep := gp.Privileges.ExpandPrivileges()
+		sp := ep.ToStringSlice()
 		// Join grantee. Filter by database name and grantee name.
 		// Finally, perform a permission comparison against expected
 		// permissions.


### PR DESCRIPTION
Inside postgresql, some privileges are [altered][0] when issuing a `GRANT`, for example `ALL` is expanded to `CREATE, TEMPORARY, CONNECT`.

When we observe the grant, we query privileges on the database to see if the ones in the grant exist. Given that they are expanded, we can't simply query for what the user gave us. Expand the privileges which need expanding before we make the query.

Closes: #92

[0]: https://www.postgresql.org/docs/15/ddl-priv.html

### How has this code been tested

  * There's a unit test to check the permissions are expanded
  * We extracted the queries the provider is using and ran them manually against a database