### PR TITLE
Support MySQL `WITH GRANT OPTION` (cherry-picks #132)

### DIFF
--- a/pkg/controller/mysql/grant/reconciler.go
+++ b/pkg/controller/mysql/grant/reconciler.go
@@ -59,7 +59,7 @@ const (
 )
 
 var (
-	grantRegex = regexp.MustCompile(`^GRANT (.+) ON (.+)\.(.+) TO .+`)
+	grantRegex = regexp.MustCompile(`^GRANT (.+) ON (\S+)\.(\S+) TO \S+@\S+?(\sWITH GRANT OPTION)?$`)
 )
 
 // Setup adds a controller that reconciles Grant managed resources.
@@ -172,9 +172,16 @@ func defaultIdentifier(identifier *string) string {
 
 func parseGrant(grant, dbname string, table string) (privileges []string) {
 	matches := grantRegex.FindStringSubmatch(grant)
-	if len(matches) == 4 && matches[2] == dbname && matches[3] == table {
-		return strings.Split(matches[1], ", ")
+	if len(matches) == 5 && matches[2] == dbname && matches[3] == table {
+		privileges := strings.Split(matches[1], ", ")
+
+		if matches[4] != "" {
+			privileges = append(privileges, "GRANT OPTION")
+		}
+
+		return privileges
 	}
+
 	return nil
 }
 

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -700,7 +700,7 @@ func TestCreate(t *testing.T) {
 						ForProvider: v1alpha1.GrantParameters{
 							Database:   pointer.StringPtr("test-example"),
 							User:       pointer.StringPtr("test-example"),
-							Privileges: v1alpha1.GrantPrivileges{"GRANT OPTION", "INSERT", "SELECT"},
+							Privileges: v1alpha1.GrantPrivileges{"INSERT", "SELECT"},
 						},
 					},
 				},
@@ -721,7 +721,36 @@ func TestCreate(t *testing.T) {
 					Spec: v1alpha1.GrantSpec{
 						ForProvider: v1alpha1.GrantParameters{
 							User:       pointer.StringPtr("test-example"),
-							Privileges: v1alpha1.GrantPrivileges{"GRANT OPTION", "INSERT", "SELECT"},
+							Privileges: v1alpha1.GrantPrivileges{"INSERT", "SELECT"},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"SuccessGrantOption": {
+			reason: "No error should be returned when we successfully create a grant with grant option",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						if strings.HasPrefix(q.String, "GRANT") &&
+							!strings.HasSuffix(q.String, "WITH GRANT OPTION") {
+							return errBoom
+						}
+
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Grant{
+					Spec: v1alpha1.GrantSpec{
+						ForProvider: v1alpha1.GrantParameters{
+							Database:   pointer.StringPtr("test-example"),
+							User:       pointer.StringPtr("test-example"),
+							Privileges: v1alpha1.GrantPrivileges{"GRANT OPTION", "ALL"},
 						},
 					},
 				},
@@ -940,6 +969,35 @@ func TestUpdate(t *testing.T) {
 			want: want{
 				err: nil,
 				c:   managed.ExternalUpdate{},
+			},
+		},
+		"SuccessGrantOption": {
+			reason: "No error should be returned when we successfully create a grant with grant option",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						if strings.HasPrefix(q.String, "GRANT") &&
+							!strings.HasSuffix(q.String, "WITH GRANT OPTION") {
+							return errBoom
+						}
+
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Grant{
+					Spec: v1alpha1.GrantSpec{
+						ForProvider: v1alpha1.GrantParameters{
+							Database:   pointer.StringPtr("test-example"),
+							User:       pointer.StringPtr("test-example"),
+							Privileges: v1alpha1.GrantPrivileges{"GRANT OPTION", "ALL"},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
 			},
 		},
 	}

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -349,6 +349,11 @@ func TestObserve(t *testing.T) {
 					ResourceUpToDate: true,
 				},
 				err: nil,
+				observedPrivileges: []string{
+					"GRANT OPTION",
+					"INSERT",
+					"SELECT",
+				},
 			},
 		},
 		"SuccessGrantOptionWithDatabase": {
@@ -381,6 +386,11 @@ func TestObserve(t *testing.T) {
 					ResourceUpToDate: true,
 				},
 				err: nil,
+				observedPrivileges: []string{
+					"GRANT OPTION",
+					"INSERT",
+					"SELECT",
+				},
 			},
 		},
 		"SuccessDiffGrants": {

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -320,6 +320,69 @@ func TestObserve(t *testing.T) {
 				observedPrivileges: []string{allPrivileges},
 			},
 		},
+		"SuccessGrantOptionNoDatabase": {
+			reason: "We should return no error if we can successfully show our grants",
+			fields: fields{
+				db: mockDB{
+					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
+						return mockRowsToSQLRows(
+							sqlmock.NewRows(
+								[]string{"Grants"},
+							).AddRow("GRANT INSERT, SELECT ON *.* TO 'success-user'@% WITH GRANT OPTION"),
+						), nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Grant{
+					Spec: v1alpha1.GrantSpec{
+						ForProvider: v1alpha1.GrantParameters{
+							User:       pointer.StringPtr("success-user"),
+							Privileges: v1alpha1.GrantPrivileges{"INSERT", "SELECT", "GRANT OPTION"},
+						},
+					},
+				},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
+		"SuccessGrantOptionWithDatabase": {
+			reason: "We should return no error if we can successfully show our grants",
+			fields: fields{
+				db: mockDB{
+					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
+						return mockRowsToSQLRows(
+							sqlmock.NewRows(
+								[]string{"Grants"},
+							).AddRow("GRANT INSERT, SELECT ON `success-db`.* TO 'success-user'@% WITH GRANT OPTION"),
+						), nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Grant{
+					Spec: v1alpha1.GrantSpec{
+						ForProvider: v1alpha1.GrantParameters{
+							Database:   pointer.StringPtr("success-db"),
+							User:       pointer.StringPtr("success-user"),
+							Privileges: v1alpha1.GrantPrivileges{"INSERT", "SELECT", "GRANT OPTION"},
+						},
+					},
+				},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+				err: nil,
+			},
+		},
 		"SuccessDiffGrants": {
 			reason: "We should return no error if different grants exist for the provided database",
 			fields: fields{
@@ -635,8 +698,30 @@ func TestCreate(t *testing.T) {
 				mg: &v1alpha1.Grant{
 					Spec: v1alpha1.GrantSpec{
 						ForProvider: v1alpha1.GrantParameters{
-							Database: pointer.StringPtr("test-example"),
-							User:     pointer.StringPtr("test-example"),
+							Database:   pointer.StringPtr("test-example"),
+							User:       pointer.StringPtr("test-example"),
+							Privileges: v1alpha1.GrantPrivileges{"GRANT OPTION", "INSERT", "SELECT"},
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"SuccessNoDatabase": {
+			reason: "No error should be returned when we successfully create a grant with no database",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Grant{
+					Spec: v1alpha1.GrantSpec{
+						ForProvider: v1alpha1.GrantParameters{
+							User:       pointer.StringPtr("test-example"),
+							Privileges: v1alpha1.GrantPrivileges{"GRANT OPTION", "INSERT", "SELECT"},
 						},
 					},
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #128

This PR cherry-picks the commits from #132 (all credit goes to the author) and fixes the merge conflicts with master.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Quoting from https://github.com/crossplane-contrib/provider-sql/pull/132

> Added unit tests to grant controller:
> 
> * Observe method:
>   * SuccessGrantOptionNoDatabase
>   * SuccessGrantOptionWithDatabase
> * Create method:
>   * SuccessGrantOption
> * Update method:
>   * SuccessGrantOption

