### PR TITLE
Give MySQL sql_log_bin at DSN level to take parameter into account

### DIFF
--- a/pkg/clients/mysql/mysql_test.go
+++ b/pkg/clients/mysql/mysql_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 )
 
@@ -11,13 +12,15 @@ func TestDSNURLEscaping(t *testing.T) {
 	user := "username"
 	rawPass := "password^"
 	tls := "true"
-	dsn := DSN(user, rawPass, endpoint, port, tls)
-	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
+	binlog := false
+	dsn := DSN(user, rawPass, endpoint, port, tls, binlog)
+	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&sql_log_bin=%s",
 		user,
 		rawPass,
 		endpoint,
 		port,
-		tls) {
+		tls,
+		strconv.FormatBool(binlog)) {
 		t.Errorf("DSN string did not match expected output with URL encoded")
 	}
 }

--- a/pkg/controller/mysql/database/reconciler_test.go
+++ b/pkg/controller/mysql/database/reconciler_test.go
@@ -64,7 +64,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte, tls *string) xsql.DB
+		newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 	}
 
 	type args struct {

--- a/pkg/controller/mysql/grant/reconciler_test.go
+++ b/pkg/controller/mysql/grant/reconciler_test.go
@@ -74,7 +74,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte, tls *string) xsql.DB
+		newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 	}
 
 	type args struct {

--- a/pkg/controller/mysql/user/reconciler_test.go
+++ b/pkg/controller/mysql/user/reconciler_test.go
@@ -72,7 +72,7 @@ func TestConnect(t *testing.T) {
 	type fields struct {
 		kube  client.Client
 		usage resource.Tracker
-		newDB func(creds map[string][]byte, tls *string) xsql.DB
+		newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 	}
 
 	type args struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #170

As actual MySQL code is not designed to execute several statements in the same connection, the `sql_log_bin` parameter value is now given at [DSN level](https://github.com/go-sql-driver/mysql/tree/v1.5.0?tab=readme-ov-file#system-variables). This ensures this parameter is always taken into account, no matter how MySQL connections are managed under the hood.

I guess this could be fixed differently, but it's the simpler way I found to manage this. Any feedbacks are welcome.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I created several `User` and `Grant` resources against a MySQL 8.0 server, with and without binlog option enabled, and then I check what was written in binlog files. It worked as expected.

[contribution process]: https://git.io/fj2m9
