### PR TITLE
Support RDS IAM authentication for MySQL

### DIFF
--- a/apis/mysql/v1alpha1/user_types.go
+++ b/apis/mysql/v1alpha1/user_types.go
@@ -49,6 +49,11 @@ type UserParameters struct {
 	// BinLog defines whether the create, delete, update operations of this user are propagated to replicas. Defaults to true
 	// +optional
 	BinLog *bool `json:"binlog,omitempty" default:"true"`
+
+	// AuthPlugin defines the MySQL auth plugin (ie. AWSAuthenticationPlugin for AWS IAM authentication when using AWS RDS )
+	// See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html
+	// +optional
+	AuthPlugin string `json:"authPlugin,omitempty" default:"mysql_native_password"`
 }
 
 // ResourceOptions define the account specific resource limits.

--- a/package/crds/mysql.sql.crossplane.io_users.yaml
+++ b/package/crds/mysql.sql.crossplane.io_users.yaml
@@ -71,6 +71,11 @@ spec:
                 description: UserParameters define the desired state of a MySQL user
                   instance.
                 properties:
+                  authPlugin:
+                    description: |-
+                      AuthPlugin defines the MySQL auth plugin (ie. AWSAuthenticationPlugin for AWS IAM authentication when using AWS RDS )
+                      See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html
+                    type: string
                   binlog:
                     description: BinLog defines whether the create, delete, update
                       operations of this user are propagated to replicas. Defaults


### PR DESCRIPTION
### Description of your changes

Fixes #106, provides the ability to create MySQL users with the AWSAuthenticationPlugin

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Honestly I have had issues testing as I don't know how to get the provider to run my image successfully, any help appreciated. 

[contribution process]: https://git.io/fj2m9
