### PR TITLE
add support for MSSQL schema in grants

### DIFF
--- a/apis/mssql/v1alpha1/grant_types.go
+++ b/apis/mssql/v1alpha1/grant_types.go
@@ -55,6 +55,11 @@ type GrantParameters struct {
 	// for available privileges.
 	Permissions GrantPermissions `json:"permissions"`
 
+	// Schema for the permissions to be granted for.
+	// +immutable
+	// +optional
+	Schema *string `json:"schema,omitempty"`
+
 	// User this grant is for.
 	// +optional
 	// +crossplane:generate:reference:type=User
@@ -100,6 +105,7 @@ type GrantStatus struct {
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="ROLE",type="string",JSONPath=".spec.forProvider.user"
 // +kubebuilder:printcolumn:name="DATABASE",type="string",JSONPath=".spec.forProvider.database"
+// +kubebuilder:printcolumn:name="SCHEMA",type="string",JSONPath=".spec.forProvider.schema"
 // +kubebuilder:printcolumn:name="PERMISSIONS",type="string",JSONPath=".spec.forProvider.permissions"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,sql}
 type Grant struct {

--- a/apis/mssql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/mssql/v1alpha1/zz_generated.deepcopy.go
@@ -183,6 +183,11 @@ func (in *GrantParameters) DeepCopyInto(out *GrantParameters) {
 		*out = make(GrantPermissions, len(*in))
 		copy(*out, *in)
 	}
+	if in.Schema != nil {
+		in, out := &in.Schema, &out.Schema
+		*out = new(string)
+		**out = **in
+	}
 	if in.User != nil {
 		in, out := &in.User, &out.User
 		*out = new(string)

--- a/package/crds/mssql.sql.crossplane.io_grants.yaml
+++ b/package/crds/mssql.sql.crossplane.io_grants.yaml
@@ -34,6 +34,9 @@ spec:
     - jsonPath: .spec.forProvider.database
       name: DATABASE
       type: string
+    - jsonPath: .spec.forProvider.schema
+      name: SCHEMA
+      type: string
     - jsonPath: .spec.forProvider.permissions
       name: PERMISSIONS
       type: string
@@ -170,6 +173,9 @@ spec:
                       type: string
                     minItems: 1
                     type: array
+                  schema:
+                    description: Schema for the permissions to be granted for.
+                    type: string
                   user:
                     description: User this grant is for.
                     type: string

--- a/pkg/controller/mssql/grant/reconciler.go
+++ b/pkg/controller/mssql/grant/reconciler.go
@@ -130,7 +130,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errNotGrant)
 	}
 
-	permissions, err := c.getPermissions(ctx, *cr.Spec.ForProvider.User)
+	permissions, err := c.getPermissions(ctx, cr)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -156,7 +156,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	username := *cr.Spec.ForProvider.User
 	permissions := strings.Join(cr.Spec.ForProvider.Permissions.ToStringSlice(), ", ")
 
-	query := fmt.Sprintf("GRANT %s TO %s", permissions, mssql.QuoteIdentifier(username))
+	query := fmt.Sprintf("GRANT %s %s TO %s", permissions, onSchemaQuery(cr), mssql.QuoteIdentifier(username))
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: query}), errGrant)
 }
 
@@ -166,7 +166,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.New(errNotGrant)
 	}
 
-	observed, err := c.getPermissions(ctx, *cr.Spec.ForProvider.User)
+	observed, err := c.getPermissions(ctx, cr)
 	if err != nil {
 		return managed.ExternalUpdate{}, err
 	}
@@ -175,16 +175,16 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	if len(toRevoke) > 0 {
 		sort.Strings(toRevoke)
-		query := fmt.Sprintf("REVOKE %s FROM %s",
-			strings.Join(toRevoke, ", "), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
+		query := fmt.Sprintf("REVOKE %s %s FROM %s",
+			strings.Join(toRevoke, ", "), onSchemaQuery(cr), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
 		if err = c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errRevoke)
 		}
 	}
 	if len(toGrant) > 0 {
 		sort.Strings(toGrant)
-		query := fmt.Sprintf("GRANT %s TO %s",
-			strings.Join(toGrant, ", "), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
+		query := fmt.Sprintf("GRANT %s %s TO %s",
+			strings.Join(toGrant, ", "), onSchemaQuery(cr), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
 		if err = c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errGrant)
 		}
@@ -200,23 +200,47 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 	username := *cr.Spec.ForProvider.User
 
-	query := fmt.Sprintf("REVOKE %s FROM %s",
+	query := fmt.Sprintf("REVOKE %s %s FROM %s",
 		strings.Join(cr.Spec.ForProvider.Permissions.ToStringSlice(), ", "),
+		onSchemaQuery(cr),
 		mssql.QuoteIdentifier(username),
 	)
 	return errors.Wrap(c.db.Exec(ctx, xsql.Query{String: query}), errRevoke)
 }
 
-func (c *external) getPermissions(ctx context.Context, username string) ([]string, error) {
-	// TODO(turkenh/ulucinar): Possible performance improvement. We first
-	//  calculate the Cartesian product, and then filter. It would be more
-	//  efficient to first filter principals by name, and then join.
-	query := fmt.Sprintf(`SELECT pe.permission_name
-	FROM sys.database_principals AS pr  
-	JOIN sys.database_permissions AS pe  
-	    ON pe.grantee_principal_id = pr.principal_id  
+// TODO(turkenh/ulucinar): Possible performance improvement. We first
+//
+//	calculate the Cartesian product, and then filter. It would be more
+//	efficient to first filter principals by name, and then join.
+const queryPermissionDefault = `SELECT pe.permission_name
+	FROM sys.database_principals AS pr
+	JOIN sys.database_permissions AS pe
+	    ON pe.grantee_principal_id = pr.principal_id
 	WHERE
-	  pr.name = %s`, mssql.QuoteValue(username))
+	      pe.class = 0 /* DATABASE (default) */
+	  AND pr.name = %s`
+
+const queryPermissionSchema = `SELECT pe.permission_name
+	FROM sys.database_principals AS pr
+	JOIN sys.database_permissions AS pe
+	    ON pe.grantee_principal_id = pr.principal_id
+	JOIN sys.schemas AS s
+	    ON s.schema_id = pe.major_id
+	WHERE
+	      pe.class = 3 /* SCHEMA */
+	  AND s.name = %s
+	  AND pr.name = %s`
+
+func (c *external) getPermissions(ctx context.Context, cr *v1alpha1.Grant) ([]string, error) {
+	var query string
+	if cr.Spec.ForProvider.Schema == nil {
+		query = fmt.Sprintf(queryPermissionDefault, mssql.QuoteValue(*cr.Spec.ForProvider.User))
+	} else {
+		query = fmt.Sprintf(queryPermissionSchema,
+			mssql.QuoteValue(*cr.Spec.ForProvider.Schema),
+			mssql.QuoteValue(*cr.Spec.ForProvider.User),
+		)
+	}
 	rows, err := c.db.Query(ctx, xsql.Query{String: query})
 	if err != nil {
 		return nil, errors.Wrap(err, errCannotGetGrants)
@@ -235,6 +259,13 @@ func (c *external) getPermissions(ctx context.Context, username string) ([]strin
 		return nil, errors.Wrap(err, errCannotGetGrants)
 	}
 	return permissions, nil
+}
+
+func onSchemaQuery(cr *v1alpha1.Grant) (schema string) {
+	if cr.Spec.ForProvider.Schema != nil {
+		schema = fmt.Sprintf("ON SCHEMA::%s", *cr.Spec.ForProvider.Schema)
+	}
+	return
 }
 
 func diffPermissions(desired, observed []string) ([]string, []string) {


### PR DESCRIPTION
### Description of your changes

This pull request allows to create MSSQL grants on Schemas not only on the database.
A new optional `schema` is introduced. If defined, the grants will be created for this schema.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested on a local Cluster with a patched image using the following resoruces.

```
apiVersion: mssql.sql.crossplane.io/v1alpha1
kind: Grant
metadata:
  name: sql-example-grant
spec:
  forProvider:
    database: test-db
    permissions:
      - CONNECT
      - CREATE TABLE
      - INSERT
      - SELECT
    userRef:
      name: sql-example-user
  providerConfigRef:
    name: test-db
---
apiVersion: mssql.sql.crossplane.io/v1alpha1
kind: Grant
metadata:
  name: sql-example-grant-dbo
spec:
  forProvider:
    schema: dbo
    database: test-db
    permissions:
      - ALTER
    userRef:
      name: sql-example-user
  providerConfigRef:
    name: test-db
```

[contribution process]: https://git.io/fj2m9
