### PR TITLE
optional binlog parameters in mysql connection string

### DIFF
--- a/apis/mysql/v1alpha1/database_types.go
+++ b/apis/mysql/v1alpha1/database_types.go
@@ -37,7 +37,7 @@ type DatabaseStatus struct {
 type DatabaseParameters struct {
 	// BinLog defines whether the create, delete, update operations of this database are propagated to replicas. Defaults to true
 	// +optional
-	BinLog *bool `json:"binlog,omitempty" default:"true"`
+	BinLog *bool `json:"binlog,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/mysql/v1alpha1/grant_types.go
+++ b/apis/mysql/v1alpha1/grant_types.go
@@ -95,7 +95,7 @@ type GrantParameters struct {
 
 	// BinLog defines whether the create, delete, update operations of this grant are propagated to replicas. Defaults to true
 	// +optional
-	BinLog *bool `json:"binlog,omitempty" default:"true"`
+	BinLog *bool `json:"binlog,omitempty"`
 }
 
 // A GrantStatus represents the observed state of a Grant.

--- a/apis/mysql/v1alpha1/user_types.go
+++ b/apis/mysql/v1alpha1/user_types.go
@@ -48,7 +48,7 @@ type UserParameters struct {
 
 	// BinLog defines whether the create, delete, update operations of this user are propagated to replicas. Defaults to true
 	// +optional
-	BinLog *bool `json:"binlog,omitempty" default:"true"`
+	BinLog *bool `json:"binlog,omitempty"`
 }
 
 // ResourceOptions define the account specific resource limits.

--- a/pkg/clients/mysql/mysql.go
+++ b/pkg/clients/mysql/mysql.go
@@ -38,11 +38,7 @@ func New(creds map[string][]byte, tls *string, binlog *bool) xsql.DB {
 		defaultTLS := "preferred"
 		tls = &defaultTLS
 	}
-	if binlog == nil {
-		defaultBinlog := true
-		binlog = &defaultBinlog
-	}
-	dsn := DSN(username, password, endpoint, port, *tls, *binlog)
+	dsn := DSN(username, password, endpoint, port, *tls, binlog)
 
 	return mySQLDB{
 		dsn:      dsn,
@@ -53,17 +49,25 @@ func New(creds map[string][]byte, tls *string, binlog *bool) xsql.DB {
 }
 
 // DSN returns the DSN URL
-func DSN(username, password, endpoint, port, tls string, binlog bool) string {
+func DSN(username, password, endpoint, port, tls string, binlog *bool) string {
 	// Use net/url UserPassword to encode the username and password
 	// This will ensure that any special characters in the username or password
 	// are percent-encoded for use in the user info portion of the DSN URL
-	return fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&sql_log_bin=%s",
+	if binlog != nil {
+		return fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&sql_log_bin=%s",
+			username,
+			password,
+			endpoint,
+			port,
+			tls,
+			strconv.FormatBool(*binlog))
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
 		username,
 		password,
 		endpoint,
 		port,
-		tls,
-		strconv.FormatBool(binlog))
+		tls)
 }
 
 // ExecTx is unsupported in MySQL.

--- a/pkg/clients/mysql/mysql_test.go
+++ b/pkg/clients/mysql/mysql_test.go
@@ -13,7 +13,7 @@ func TestDSNURLEscaping(t *testing.T) {
 	rawPass := "password^"
 	tls := "true"
 	binlog := false
-	dsn := DSN(user, rawPass, endpoint, port, tls, binlog)
+	dsn := DSN(user, rawPass, endpoint, port, tls, &binlog)
 	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&sql_log_bin=%s",
 		user,
 		rawPass,
@@ -21,6 +21,23 @@ func TestDSNURLEscaping(t *testing.T) {
 		port,
 		tls,
 		strconv.FormatBool(binlog)) {
+		t.Errorf("DSN string did not match expected output with URL encoded and binlog")
+	}
+}
+
+func TestDSNURLEscapingWithoutBinLog(t *testing.T) {
+	endpoint := "endpoint"
+	port := "3306"
+	user := "username"
+	rawPass := "password^"
+	tls := "true"
+	dsn := DSN(user, rawPass, endpoint, port, tls, nil)
+	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
+		user,
+		rawPass,
+		endpoint,
+		port,
+		tls) {
 		t.Errorf("DSN string did not match expected output with URL encoded")
 	}
 }


### PR DESCRIPTION
The MySQL binlog parameter in dsn (connection string) is currently mandatory, but this causes errors like
 _Error 1227: Access denied; you need (at least one of) the SUPER, BINLOG ADMIN privilege(s) for this operation_ 
with AWS RDS MariaDB and default admin user.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Binlog parameter for Users, Grants and Databases becomes optional and does not have a default value at all.

In this way, the `sql_bin_log` parameter in DSN becomes optional and it is added only when binlog is explicitly set to true/false in one of the managed resources.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes the side effect of #171 in AWS RDS MariaDB.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Unit tests updated and added one more to cover the new case of missing binlog.
Tested with AWS RDS Mariadb: provisioned users, databases and grants.

[contribution process]: https://git.io/fj2m9
