### PR TITLE
update helm repo before intalling mariadb

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -337,6 +337,7 @@ setup_mariadb_no_tls() {
       --from-literal port="3306"
 
   "${HELM}" repo add bitnami https://charts.bitnami.com/bitnami >/dev/null
+  "${HELM}" repo update
   "${HELM}" install mariadb bitnami/mariadb \
       --version 11.3.0 \
       --set auth.rootPassword="${MARIADB_ROOT_PW}" \
@@ -377,6 +378,7 @@ EOF
   )
 
   "${HELM}" repo add bitnami https://charts.bitnami.com/bitnami >/dev/null
+  "${HELM}" repo update
   "${HELM}" install mariadb bitnami/mariadb \
       --version 11.3.0 \
       --values <(echo "$values") \


### PR DESCRIPTION
### Description of your changes
We encountered the following error in the CI pipeline on master.

```
>>>>>>> installing MariaDB with no TLS
secret/mariadb-creds created
index.go:346: skipping loading invalid entry for chart "airflow" "" from https://charts.bitnami.com/bitnami: validation: chart.metadata.name is required
index.go:346: skipping loading invalid entry for chart "airflow" "" from /home/runner/.cache/helm/repository/bitnami-index.yaml: validation: chart.metadata.name is required
Error: INSTALLATION FAILED: failed to download "bitnami/mariadb" at version "11.3.0"
```

Fixes #
Apply a helm repo update before installing.

I have:

- [ x ] Read and followed Crossplane's [contribution process].
- [ x ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

```
make clean
make build
make reviewable
make e2e
```

[contribution process]: https://git.io/fj2m9
