### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - directory: /
+    package-ecosystem: gomod
+    schedule:
+      interval: weekly
+
+  - directory: /
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This might be useful to keep dependencies up-to-date and prevent vulnerabilities to proliferate.
