### PR TITLE
feat(mysql): add optional authPlugin parameter for MySQL user creation

### DIFF
--- a/apis/mysql/v1alpha1/user_types.go
+++ b/apis/mysql/v1alpha1/user_types.go
@@ -49,6 +49,12 @@ type UserParameters struct {
 	// BinLog defines whether the create, delete, update operations of this user are propagated to replicas. Defaults to true
 	// +optional
 	BinLog *bool `json:"binlog,omitempty"`
+
+	// AuthPlugin defines the MySQL authentication plugin.
+	// Supported values: "mysql_native_password", "caching_sha2_password", "AWSAuthenticationPlugin".
+	// +kubebuilder:validation:Enum=mysql_native_password;caching_sha2_password;AWSAuthenticationPlugin
+	// +optional
+	AuthPlugin string `json:"authPlugin,omitempty,"`
 }
 
 // ResourceOptions define the account specific resource limits.

--- a/package/crds/mysql.sql.crossplane.io_users.yaml
+++ b/package/crds/mysql.sql.crossplane.io_users.yaml
@@ -71,6 +71,15 @@ spec:
                 description: UserParameters define the desired state of a MySQL user
                   instance.
                 properties:
+                  authPlugin:
+                    description: |-
+                      AuthPlugin defines the MySQL authentication plugin.
+                      Supported values: "mysql_native_password", "caching_sha2_password", "AWSAuthenticationPlugin".
+                    enum:
+                    - mysql_native_password
+                    - caching_sha2_password
+                    - AWSAuthenticationPlugin
+                    type: string
                   binlog:
                     description: BinLog defines whether the create, delete, update
                       operations of this user are propagated to replicas. Defaults

--- a/pkg/controller/mysql/user/reconciler.go
+++ b/pkg/controller/mysql/user/reconciler.go
@@ -259,7 +259,10 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	ro := resourceOptionsToClauses(cr.Spec.ForProvider.ResourceOptions)
-	if err := c.executeCreateUserQuery(ctx, username, host, ro, pw); err != nil {
+
+	authplugin := cr.Spec.ForProvider.AuthPlugin
+
+	if err := c.executeCreateUserQuery(ctx, username, host, ro, pw, authplugin); err != nil {
 		return managed.ExternalCreation{}, err
 	}
 
@@ -272,17 +275,30 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}, nil
 }
 
-func (c *external) executeCreateUserQuery(ctx context.Context, username string, host string, resourceOptionsClauses []string, pw string) error {
+func (c *external) executeCreateUserQuery(ctx context.Context, username string, host string, resourceOptionsClauses []string, pw string, authplugin string) error {
 	resourceOptions := ""
 	if len(resourceOptionsClauses) != 0 {
 		resourceOptions = fmt.Sprintf(" WITH %s", strings.Join(resourceOptionsClauses, " "))
 	}
 
+	var authStm string
+
+	if len(authplugin) > 0 {
+		switch authplugin {
+			case "mysql_native_password", "caching_sha2_password":
+				authStm = fmt.Sprintf("WITH %s BY %s", authplugin, mysql.QuoteValue(pw))
+			case "AWSAuthenticationPlugin":
+				authStm = fmt.Sprintf("WITH %s AS %s", authplugin, mysql.QuoteValue("RDS"))
+		}
+	} else {
+		authStm = fmt.Sprintf("BY %s", mysql.QuoteValue(pw))
+	}
+
 	query := fmt.Sprintf(
-		"CREATE USER %s@%s IDENTIFIED BY %s%s",
+		"CREATE USER %s@%s IDENTIFIED %s%s",
 		mysql.QuoteValue(username),
 		mysql.QuoteValue(host),
-		mysql.QuoteValue(pw),
+		authStm,
 		resourceOptions,
 	)
 


### PR DESCRIPTION
### Description of your changes
This pull request adds the ability to specify an authentication plugin when creating MySQL users. This enhancement allows users to define which authentication method should be used, providing greater flexibility and compatibility with various MySQL setups.
Supported Authentication Plugins: mysql_native_password, caching_sha2_password, AWSAuthenticationPlugin.

Fixes #106 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
```
make build
make reviewable
make e2e
```
I built and tested the package locally using the following resources as well .
```
apiVersion: mysql.sql.crossplane.io/v1alpha1
kind: User
metadata:
  name: we1
spec:
  forProvider:
    resourceOptions:
      maxQueriesPerHour: 1000
      maxUpdatesPerHour: 1000
      maxConnectionsPerHour: 100
      maxUserConnections: 10
  writeConnectionSecretToRef:
    name: we1
    namespace: default
---
apiVersion: mysql.sql.crossplane.io/v1alpha1
kind: User
metadata:
  name: we2
spec:
  forProvider:
    authPlugin: caching_sha2_password
  writeConnectionSecretToRef:
    name: we2
    namespace: default
---
apiVersion: mysql.sql.crossplane.io/v1alpha1
kind: User
metadata:
  name: we3
spec:
  forProvider:
    authPlugin: AWSAuthenticationPlugin
  writeConnectionSecretToRef:
    name: we3
    namespace: default
```

