### PR TITLE
feat(pgsql): extend Grant kind specification with schema, objects, objectType, colums.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .work
 _output
 __debug_bin
+.tool-versions

--- a/apis/postgresql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/postgresql/v1alpha1/zz_generated.deepcopy.go
@@ -411,6 +411,21 @@ func (in *GrantParameters) DeepCopyInto(out *GrantParameters) {
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Schema != nil {
+		in, out := &in.Schema, &out.Schema
+		*out = new(string)
+		**out = **in
+	}
+	if in.SchemaRef != nil {
+		in, out := &in.SchemaRef, &out.SchemaRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.SchemaSelector != nil {
+		in, out := &in.SchemaSelector, &out.SchemaSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MemberOf != nil {
 		in, out := &in.MemberOf, &out.MemberOf
 		*out = new(string)
@@ -430,6 +445,16 @@ func (in *GrantParameters) DeepCopyInto(out *GrantParameters) {
 		in, out := &in.RevokePublicOnDb, &out.RevokePublicOnDb
 		*out = new(bool)
 		**out = **in
+	}
+	if in.Objects != nil {
+		in, out := &in.Objects, &out.Objects
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Columns != nil {
+		in, out := &in.Columns, &out.Columns
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/package/crds/postgresql.sql.crossplane.io_grants.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_grants.yaml
@@ -83,6 +83,13 @@ spec:
                 description: GrantParameters define the desired state of a PostgreSQL
                   grant instance.
                 properties:
+                  columns:
+                    description: |-
+                      The columns upon which to grant the privileges.
+                      Required when object_type is column. You cannot specify this option if the object_type is not column
+                    items:
+                      type: string
+                    type: array
                   database:
                     description: Database this grant is for.
                     type: string
@@ -242,6 +249,30 @@ spec:
                             type: string
                         type: object
                     type: object
+                  objectType:
+                    description: ObjectType is the PostgreSQL object type to grant
+                      the privileges on.
+                    enum:
+                    - database
+                    - schema
+                    - table
+                    - sequence
+                    - function
+                    - procedure
+                    - routine
+                    - foreign_data_wrapper
+                    - foreign_server
+                    - column
+                    type: string
+                  objects:
+                    description: |-
+                      Objects are the objects upon which to grant the privileges.
+                      An empty list (the default) means to grant permissions on all objects of the specified type.
+                      You cannot specify this option if the objectType is database or schema.
+                      When objectType is column, only one value is allowed.
+                    items:
+                      type: string
+                    type: array
                   privileges:
                     description: |-
                       Privileges to be granted.
@@ -336,6 +367,85 @@ spec:
                             type: string
                         type: object
                     type: object
+                  schema:
+                    description: Schema this grant is for.
+                    type: string
+                  schemaRef:
+                    description: SchemaRef references the schema object this grant
+                      it for.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  schemaSelector:
+                    description: SchemaSelector selects a reference to a Schema this
+                      grant is for.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   withOption:
                     description: |-
                       WithOption allows an option to be set on the grant.
@@ -345,6 +455,8 @@ spec:
                     - ADMIN
                     - GRANT
                     type: string
+                required:
+                - objectType
                 type: object
               managementPolicies:
                 default:

--- a/pkg/controller/postgresql/grant/reconciler.go
+++ b/pkg/controller/postgresql/grant/reconciler.go
@@ -51,6 +51,7 @@ const (
 	errSelectGrant  = "cannot select grant"
 	errCreateGrant  = "cannot create grant"
 	errRevokeGrant  = "cannot revoke grant"
+	errNoSchema     = "schema not passed or could not be resolved"
 	errNoRole       = "role not passed or could not be resolved"
 	errNoDatabase   = "database not passed or could not be resolved"
 	errNoPrivileges = "privileges not passed"
@@ -137,6 +138,41 @@ const (
 	roleDatabase grantType = "ROLE_DATABASE"
 )
 
+// sliceContainsStr checks if a slice contains a specific string.
+func sliceContainsStr(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func validateGrantParams(gp v1alpha1.GrantParameters) error {
+	if gp.Schema == nil && !sliceContainsStr([]string{"database", "foreign_data_wrapper", "foreign_server"}, gp.ObjectType) {
+		return fmt.Errorf("parameter 'schema' is mandatory for grant resource")
+	}
+	if len(gp.Objects) > 0 && (gp.ObjectType == "database" || gp.ObjectType == "schema") {
+		return fmt.Errorf("cannot specify `objects` when `object_type` is `database` or `schema`")
+	}
+	if len(gp.Columns) > 0 && gp.ObjectType != "column" {
+		return fmt.Errorf("cannot specify `columns` when `object_type` is not `column`")
+	}
+	if len(gp.Columns) == 0 && gp.ObjectType == "column" {
+		return fmt.Errorf("must specify `columns` when `object_type` is `column`")
+	}
+	if len(gp.Privileges) != 1 && gp.ObjectType == "column" {
+		return fmt.Errorf("must specify exactly 1 `privileges` when `object_type` is `column`")
+	}
+	if len(gp.Objects) != 1 && gp.ObjectType == "column" {
+		return fmt.Errorf("must specify exactly 1 table in the `objects` field when `object_type` is `column`")
+	}
+	if len(gp.Objects) != 1 && (gp.ObjectType == "foreign_data_wrapper" || gp.ObjectType == "foreign_server") {
+		return fmt.Errorf("one element must be specified in `objects` when `object_type` is `foreign_data_wrapper` or `foreign_server`")
+	}
+	return nil
+}
+
 func identifyGrantType(gp v1alpha1.GrantParameters) (grantType, error) {
 	pc := len(gp.Privileges)
 
@@ -194,32 +230,41 @@ func selectGrantQuery(gp v1alpha1.GrantParameters, q *xsql.Query) error {
 
 		ep := gp.Privileges.ExpandPrivileges()
 		sp := ep.ToStringSlice()
+
 		// Join grantee. Filter by database name and grantee name.
 		// Finally, perform a permission comparison against expected
 		// permissions.
 		q.String = "SELECT EXISTS(SELECT 1 " +
-			"FROM pg_database db, " +
-			"aclexplode(datacl) as acl " +
-			"INNER JOIN pg_roles s ON acl.grantee = s.oid " +
-			// Filter by database, role and grantable setting
-			"WHERE db.datname=$1 " +
-			"AND s.rolname=$2 " +
-			"AND acl.is_grantable=$3 " +
-			"GROUP BY db.datname, s.rolname, acl.is_grantable " +
-			// Check privileges match. Convoluted right-hand-side is necessary to
-			// ensure identical sort order of the input permissions.
-			"HAVING array_agg(acl.privilege_type ORDER BY privilege_type ASC) " +
-			"= (SELECT array(SELECT unnest($4::text[]) as perms ORDER BY perms ASC)))"
+			"FROM pg_database db " +
+			"JOIN pg_namespace nsp ON db.datname = $1 " +
+			"JOIN LATERAL aclexplode(nsp.nspacl) acl ON true " +
+			"JOIN pg_roles s ON acl.grantee = s.oid " +
+			// Filter by role, schema and grantable setting
+			"WHERE nsp.nspname = $2 " +
+			"AND s.rolname = $3 " +
+			"AND acl.is_grantable = $6 " +
+			"GROUP BY db.datname, nsp.nspname, s.rolname, acl.is_grantable " +
+			"HAVING array_agg(acl.privilege_type ORDER BY privilege_type ASC) = " +
+			"(SELECT array(SELECT unnest($7::text[]) ORDER BY 1)))"
 
 		q.Parameters = []interface{}{
 			gp.Database,
+			gp.Schema,
 			gp.Role,
+			gp.ObjectType,
+			gp.Objects,
 			gro,
 			pq.Array(sp),
 		}
-		return nil
 	}
 	return errors.New(errUnknownGrant)
+}
+
+func withSchema(schema *string) string {
+	if schema != nil {
+		return fmt.Sprintf("IN SCHEMA %s", *schema)
+	}
+	return ""
 }
 
 func withOption(option *v1alpha1.GrantOption) string {
@@ -262,17 +307,19 @@ func createGrantQueries(gp v1alpha1.GrantParameters, ql *[]xsql.Query) error { /
 
 		*ql = append(*ql,
 			// REVOKE ANY MATCHING EXISTING PERMISSIONS
-			xsql.Query{String: fmt.Sprintf("REVOKE %s ON DATABASE %s FROM %s",
+			xsql.Query{String: fmt.Sprintf("REVOKE %s ON DATABASE %s %s FROM %s",
 				sp,
 				db,
+				withSchema(gp.Schema),
 				ro,
 			)},
 
 			// GRANT REQUESTED PERMISSIONS
-			xsql.Query{String: fmt.Sprintf("GRANT %s ON DATABASE %s TO %s %s",
+			xsql.Query{String: fmt.Sprintf("GRANT %s ON DATABASE %s TO %s %s %s",
 				sp,
 				db,
 				ro,
+				withSchema(gp.Schema),
 				withOption(gp.WithOption),
 			)},
 		)
@@ -305,9 +352,10 @@ func deleteGrantQuery(gp v1alpha1.GrantParameters, q *xsql.Query) error {
 		)
 		return nil
 	case roleDatabase:
-		q.String = fmt.Sprintf("REVOKE %s ON DATABASE %s FROM %s",
+		q.String = fmt.Sprintf("REVOKE %s ON DATABASE %s %s FROM %s",
 			strings.Join(gp.Privileges.ToStringSlice(), ","),
 			pq.QuoteIdentifier(*gp.Database),
+			withSchema(gp.Schema),
 			ro,
 		)
 		return nil
@@ -355,6 +403,11 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	cr, ok := mg.(*v1alpha1.Grant)
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotGrant)
+	}
+
+	// Validate grant specs
+	if err := validateGrantParams(cr.Spec.ForProvider); err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errInvalidParams)
 	}
 
 	var queries []xsql.Query


### PR DESCRIPTION

### Description of your changes

Extend Grant kind specification with schema, objects, objectType, colums.
This will allow granting more fine-grained permissions on PGSQL objects.

Fixes #217 

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

TODO

[contribution process]: https://git.io/fj2m9
