### PR TITLE
ci: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Publish Artifacts to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output
           path: _output/**


### PR DESCRIPTION
### Description of your changes

v3 is no longer supported and fails https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This will allow CI to run succesfully for other pending changes if they are rebased.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I checked the migration log and dont think our use requires any actions.

[contribution process]: https://git.io/fj2m9
