### PR TITLE
chore: add chlunde to maintainers list

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -13,6 +13,7 @@ Please see [GOVERNANCE.md] for governance guidelines and responsibilities.
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
 * Javier Palomo ([jvrplmlmn](https://github.com/jvrplmlmn))
 * Iain Lane ([iainlane](https://github.com/iainlane))
+* Carl Henrik Lunde ([chlunde](https://github.com/chlunde))
 
 ## Emeritus maintainers
 


### PR DESCRIPTION
Carl has been a solid contributor and would like to help out more. This PR adds him to the maintainers list in OWNERS.md.
