### PR TITLE
chore: Update Go to 1.23.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'
   GOLANGCI_VERSION: 'v2.1.2'
   DOCKER_BUILDX_VERSION: 'v0.23.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/crossplane-contrib/provider-sql
 
-go 1.21
-
-toolchain go1.21.11
+go 1.23.9
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
### Description of your changes

Go 1.23.9 is a security update, and we also need to update
Go to get dependabot security updates out (dependabot does not
run 'go mod tidy').

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`make && make e2e`

[contribution process]: https://git.io/fj2m9
