### PR TITLE
test: add coverage of managementPolicies to e2e

### DIFF
--- a/examples/postgresql/database.yaml
+++ b/examples/postgresql/database.yaml
@@ -14,3 +14,12 @@ spec:
   forProvider:
     allowConnections: true
     owner: "ownerrole"
+---
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: db-observe
+spec:
+  managementPolicies:
+  - Observe
+  forProvider: {}


### PR DESCRIPTION
### Description of your changes

Add basic coverage of managementPolicies to e2e tests. I've only covered one resource as this is code managed i crossplane-runtime, but we want to ensure everything is wired correctly.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
e2e tests

[contribution process]: https://git.io/fj2m9
