### PR TITLE
chore: remove duplicate entry of golangci version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,11 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-GOLANGCILINT_VERSION ?= 1.63.4
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 GO_SUBDIRS += cmd pkg apis
 GO111MODULE = on
-GOLANGCILINT_VERSION = 2.1.2
+GOLANGCILINT_VERSION ?= 2.1.2
 -include build/makelib/golang.mk
 
 # ====================================================================================

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,20 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
+GOLANGCILINT_VERSION ?= 2.1.2
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 GO_SUBDIRS += cmd pkg apis
 GO111MODULE = on
-GOLANGCILINT_VERSION ?= 2.1.2
 -include build/makelib/golang.mk
 
 # ====================================================================================
 # Setup Kubernetes tools
-KIND_NODE_IMAGE_TAG ?= v1.23.4
-DOCKER_REGISTRY ?= "xpkg.upbound.io"
+KIND_NODE_IMAGE_TAG ?= v1.30.13
+KIND_VERSION ?= v0.29.0
+KUBECTL_VERSION ?= v1.30.13
+CROSSPLANE_CLI_VERSION ?= v1.20.0
+DOCKER_REGISTRY ?= "xpkg.crossplane.io"
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
@@ -45,10 +48,10 @@ IMAGES = provider-sql
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib
+XPKG_REG_ORGS ?= xpkg.crossplane.io/crossplane-contrib
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.
-XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane-contrib
+XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.crossplane.io/crossplane-contrib
 XPKGS = provider-sql
 -include build/makelib/xpkg.mk
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ KIND_NODE_IMAGE_TAG ?= v1.30.13
 KIND_VERSION ?= v0.29.0
 KUBECTL_VERSION ?= v1.30.13
 CROSSPLANE_CLI_VERSION ?= v1.20.0
-DOCKER_REGISTRY ?= "xpkg.crossplane.io"
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
@@ -48,10 +47,10 @@ IMAGES = provider-sql
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= xpkg.crossplane.io/crossplane-contrib
+XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.
-XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.crossplane.io/crossplane-contrib
+XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane-contrib
 XPKGS = provider-sql
 -include build/makelib/xpkg.mk
 

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -102,8 +102,8 @@ EOF
 
   echo_step "tag controller image and load it into kind cluster"
 
-  docker tag "${CONTROLLER_IMAGE}" "xpkg.upbound.io/${PACKAGE_NAME}"
-  "${KIND}" load docker-image "xpkg.upbound.io/${PACKAGE_NAME}" --name="${K8S_CLUSTER}"
+  docker tag "${CONTROLLER_IMAGE}" "xpkg.crossplane.io/${PACKAGE_NAME}"
+  "${KIND}" load docker-image "xpkg.crossplane.io/${PACKAGE_NAME}" --name="${K8S_CLUSTER}"
 
   echo_step "create crossplane-system namespace"
 


### PR DESCRIPTION
### Description of your changes

Remove duplicate and overridden entry of golangci-lint version from Makefile, most possibly a leftover from the last PRs.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
make reviewable test

[contribution process]: https://git.io/fj2m9
