### PR TITLE
Relax MySQL Database schema, forProvider is optional

### DIFF
--- a/apis/mysql/v1alpha1/database_types.go
+++ b/apis/mysql/v1alpha1/database_types.go
@@ -25,7 +25,8 @@ import (
 // A DatabaseSpec defines the desired state of a Database.
 type DatabaseSpec struct {
 	xpv1.ResourceSpec `json:",inline"`
-	ForProvider       DatabaseParameters `json:"forProvider"`
+	// +optional
+	ForProvider DatabaseParameters `json:"forProvider"`
 }
 
 // A DatabaseStatus represents the observed state of a Database.

--- a/package/crds/mysql.sql.crossplane.io_databases.yaml
+++ b/package/crds/mysql.sql.crossplane.io_databases.yaml
@@ -241,8 +241,6 @@ spec:
                 - name
                 - namespace
                 type: object
-            required:
-            - forProvider
             type: object
           status:
             description: A DatabaseStatus represents the observed state of a Database.


### PR DESCRIPTION
### Description of your changes

This was a breaking change which was not strictly required. Make the
field optional again so we don't cause any uneccesary breaking changes
for users upgrading from 0.7.0.

Thanks to @cm3brian for the report!

Fixes #241

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Should be covered by e2e tests. The field is not a pointer so everything should behave identical to how it works already. 

[contribution process]: https://git.io/fj2m9
