### PR TITLE
Repair e2e by swapping MariaDB/PostgreSQL helm charts with k8s manifests

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -34,6 +34,7 @@ echo_error() {
 
 # ------------------------------
 projectdir="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../.. && pwd )"
+scriptdir="$(dirname "$0")"
 
 # get the build environment variables from the special build.vars target in the main makefile
 eval $(make --no-print-directory -C ${projectdir} build.vars)
@@ -272,109 +273,12 @@ cleanup_tls_certs() {
 
 setup_provider_config_no_tls() {
   echo_step "creating ProviderConfig with no TLS ${API_TYPE}"
-  if [ "${API_TYPE}" == "namespaced" ]; then
-    local yaml="$( cat <<EOF
-apiVersion: mysql.sql.${APIGROUP_SUFFIX}crossplane.io/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  credentials:
-    source: MySQLConnectionSecret
-    connectionSecretRef:
-#     namespace: default
-      name: mariadb-creds
-EOF
-  )"
-
-  else
-    local yaml="$( cat <<EOF
-apiVersion: mysql.sql.${APIGROUP_SUFFIX}crossplane.io/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  credentials:
-    source: MySQLConnectionSecret
-    connectionSecretRef:
-      namespace: default
-      name: mariadb-creds
-EOF
-  )"
-  fi
-
-  echo "${yaml}" | "${KUBECTL}" apply -f -
+  "${KUBECTL}" apply -f "${scriptdir}/mariadb.providerconfig.notls.${API_TYPE}.yaml"
 }
 
 setup_provider_config_tls() {
   echo_step "creating ProviderConfig with TLS ${API_TYPE}"
-  if [ "${API_TYPE}" == "cluster" ]; then
-    local yaml="$( cat <<EOF
-apiVersion: mysql.sql.${APIGROUP_SUFFIX}crossplane.io/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  credentials:
-    source: MySQLConnectionSecret
-    connectionSecretRef:
-      namespace: default
-      name: mariadb-creds
-  tls: custom
-  tlsConfig:
-    caCert:
-      secretRef:
-        namespace: default
-        name: mariadb-creds
-        key: ca-cert.pem
-    clientCert:
-      secretRef:
-        namespace: default
-        name: mariadb-creds
-        key: client-cert.pem
-    clientKey:
-      secretRef:
-        namespace: default
-        name: mariadb-creds
-        key: client-key.pem
-    insecureSkipVerify: true
-EOF
-    )"
-  else
-    local yaml="$( cat <<EOF
-apiVersion: mysql.sql.${APIGROUP_SUFFIX}crossplane.io/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  credentials:
-    source: MySQLConnectionSecret
-    connectionSecretRef:
-#     namespace: default
-      name: mariadb-creds
-  tls: custom
-  tlsConfig:
-    caCert:
-      secretRef:
-        namespace: default
-        name: mariadb-creds
-        key: ca-cert.pem
-    clientCert:
-      secretRef:
-        namespace: default
-        name: mariadb-creds
-        key: client-cert.pem
-    clientKey:
-      secretRef:
-        namespace: default
-        name: mariadb-creds
-        key: client-key.pem
-    insecureSkipVerify: true
-EOF
-    )"
-  fi
-
-  echo "${yaml}" | "${KUBECTL}" apply -f -
+  "${KUBECTL}" apply -f "${scriptdir}/mariadb.providerconfig.tls.${API_TYPE}.yaml"
 }
 
 cleanup_provider_config() {
@@ -390,63 +294,10 @@ setup_mariadb_no_tls() {
       --from-literal endpoint="mariadb.default.svc.cluster.local" \
       --from-literal port="3306"
 
-  # Deploy MariaDB using official mariadb image
-  local yaml="$( cat <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: mariadb
-  namespace: default
-spec:
-  ports:
-  - port: 3306
-    targetPort: 3306
-  selector:
-    app: mariadb
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: mariadb
-  namespace: default
-spec:
-  serviceName: mariadb
-  replicas: 1
-  selector:
-    matchLabels:
-      app: mariadb
-  template:
-    metadata:
-      labels:
-        app: mariadb
-    spec:
-      containers:
-      - name: mariadb
-        image: mariadb:12
-        env:
-        - name: MARIADB_ROOT_PASSWORD
-          value: "${MARIADB_ROOT_PW}"
-        ports:
-        - containerPort: 3306
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/mysql
-        readinessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - mariadb -uroot -p\${MARIADB_ROOT_PASSWORD} -e "SELECT 1"
-          initialDelaySeconds: 10
-          periodSeconds: 5
-      volumes:
-      - name: data
-        emptyDir: {}
-EOF
-  )"
-  echo "${yaml}" | "${KUBECTL}" apply -f -
+  "${KUBECTL}" apply -f ${scriptdir}/mariadb.server.yaml
 
   echo_step "Waiting for MariaDB to be ready"
+  "${KUBECTL}" wait --for=create pod mariadb-0
   "${KUBECTL}" wait --for=condition=ready pod -l app=mariadb --timeout=120s
 }
 
@@ -469,79 +320,10 @@ setup_mariadb_tls() {
   "
 
   # Deploy MariaDB using official mariadb image with TLS
-  local yaml="$( cat <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: mariadb
-  namespace: default
-spec:
-  ports:
-  - port: 3306
-    targetPort: 3306
-  selector:
-    app: mariadb
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: mariadb
-  namespace: default
-spec:
-  serviceName: mariadb
-  replicas: 1
-  selector:
-    matchLabels:
-      app: mariadb
-  template:
-    metadata:
-      labels:
-        app: mariadb
-    spec:
-      containers:
-      - name: mariadb
-        image: mariadb:12
-        args:
-        - --ssl
-        - --require-secure-transport=ON
-        - --ssl-ca=/etc/mysql/certs/ca-cert.pem
-        - --ssl-cert=/etc/mysql/certs/server-cert.pem
-        - --ssl-key=/etc/mysql/certs/server-key.pem
-        env:
-        - name: MARIADB_ROOT_PASSWORD
-          value: "${MARIADB_ROOT_PW}"
-        ports:
-        - containerPort: 3306
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/mysql
-        - name: tls-certificates
-          mountPath: /etc/mysql/certs
-          readOnly: true
-        - name: init-script
-          mountPath: /docker-entrypoint-initdb.d
-        readinessProbe:
-          exec:
-            command:
-            - bash
-            - -c
-            - mariadb -uroot -p\${MARIADB_ROOT_PASSWORD} -e "SELECT 1"
-          initialDelaySeconds: 10
-          periodSeconds: 5
-      volumes:
-      - name: data
-        emptyDir: {}
-      - name: tls-certificates
-        secret:
-          secretName: mariadb-server-tls
-      - name: init-script
-        configMap:
-          name: mariadb-init-script
-EOF
-  )"
-  echo "${yaml}" | "${KUBECTL}" apply -f -
+  "${KUBECTL}" apply -f "${scriptdir}/mariadb.tls.server.yaml"
 
   echo_step "Waiting for MariaDB to be ready"
+  "${KUBECTL}" wait --for=create pod mariadb-0
   "${KUBECTL}" wait --for=condition=ready pod -l app=mariadb --timeout=120s
 }
 

--- a/cluster/local/mariadb.providerconfig.notls.cluster.yaml
+++ b/cluster/local/mariadb.providerconfig.notls.cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: mysql.sql.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: MySQLConnectionSecret
+    connectionSecretRef:
+      namespace: default
+      name: mariadb-creds

--- a/cluster/local/mariadb.providerconfig.notls.namespaced.yaml
+++ b/cluster/local/mariadb.providerconfig.notls.namespaced.yaml
@@ -1,0 +1,10 @@
+apiVersion: mysql.sql.m.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: MySQLConnectionSecret
+    connectionSecretRef:
+      name: mariadb-creds
+

--- a/cluster/local/mariadb.providerconfig.tls.cluster.yaml
+++ b/cluster/local/mariadb.providerconfig.tls.cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: mysql.sql.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: MySQLConnectionSecret
+    connectionSecretRef:
+      namespace: default
+      name: mariadb-creds
+  tls: custom
+  tlsConfig:
+    caCert:
+      secretRef:
+        namespace: default
+        name: mariadb-creds
+        key: ca-cert.pem
+    clientCert:
+      secretRef:
+        namespace: default
+        name: mariadb-creds
+        key: client-cert.pem
+    clientKey:
+      secretRef:
+        namespace: default
+        name: mariadb-creds
+        key: client-key.pem
+    insecureSkipVerify: true

--- a/cluster/local/mariadb.providerconfig.tls.namespaced.yaml
+++ b/cluster/local/mariadb.providerconfig.tls.namespaced.yaml
@@ -1,0 +1,27 @@
+apiVersion: mysql.sql.m.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: MySQLConnectionSecret
+    connectionSecretRef:
+      name: mariadb-creds
+  tls: custom
+  tlsConfig:
+    caCert:
+      secretRef:
+        namespace: default
+        name: mariadb-creds
+        key: ca-cert.pem
+    clientCert:
+      secretRef:
+        namespace: default
+        name: mariadb-creds
+        key: client-cert.pem
+    clientKey:
+      secretRef:
+        namespace: default
+        name: mariadb-creds
+        key: client-key.pem
+    insecureSkipVerify: true

--- a/cluster/local/mariadb.server.yaml
+++ b/cluster/local/mariadb.server.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  namespace: default
+spec:
+  ports:
+  - port: 3306
+    targetPort: 3306
+  selector:
+    app: mariadb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mariadb
+  namespace: default
+spec:
+  serviceName: mariadb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:12
+        env:
+        - name: MARIADB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-creds
+              key: password
+        ports:
+        - containerPort: 3306
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+        readinessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - mariadb -uroot -p${MARIADB_ROOT_PASSWORD} -e "SELECT 1"
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/cluster/local/mariadb.tls.server.yaml
+++ b/cluster/local/mariadb.tls.server.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  namespace: default
+spec:
+  ports:
+  - port: 3306
+    targetPort: 3306
+  selector:
+    app: mariadb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mariadb
+  namespace: default
+spec:
+  serviceName: mariadb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:12
+        args:
+        - --ssl
+        - --require-secure-transport=ON
+        - --ssl-ca=/etc/mysql/certs/ca-cert.pem
+        - --ssl-cert=/etc/mysql/certs/server-cert.pem
+        - --ssl-key=/etc/mysql/certs/server-key.pem
+        env:
+        - name: MARIADB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-creds
+              key: password
+        ports:
+        - containerPort: 3306
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+        - name: tls-certificates
+          mountPath: /etc/mysql/certs
+          readOnly: true
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+        readinessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - mariadb -uroot -p${MARIADB_ROOT_PASSWORD} -e "SELECT 1"
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: tls-certificates
+        secret:
+          secretName: mariadb-server-tls
+      - name: init-script
+        configMap:
+          name: mariadb-init-script

--- a/cluster/local/postgres.providerconfig.cluster.yaml
+++ b/cluster/local/postgres.providerconfig.cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  sslMode: disable
+  credentials:
+    source: PostgreSQLConnectionSecret
+    connectionSecretRef:
+      namespace: default
+      name: postgresdb-creds

--- a/cluster/local/postgres.providerconfig.namespaced.yaml
+++ b/cluster/local/postgres.providerconfig.namespaced.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  sslMode: disable
+  credentials:
+    source: PostgreSQLConnectionSecret
+    connectionSecretRef:
+      name: postgresdb-creds

--- a/cluster/local/postgres.server.yaml
+++ b/cluster/local/postgres.server.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresdb-postgresql
+  namespace: default
+spec:
+  ports:
+  - port: 5432
+    targetPort: 5432
+  selector:
+    app: postgresdb-postgresql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresdb-postgresql
+  namespace: default
+spec:
+  serviceName: postgresdb-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresdb-postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresdb-postgresql
+    spec:
+      containers:
+      - name: postgresql
+        image: postgres:18
+        env:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgresdb-creds
+              key: password
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - postgres
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/cluster/local/postgresdb_functions.sh
+++ b/cluster/local/postgresdb_functions.sh
@@ -3,74 +3,19 @@ set -e
 
 setup_postgresdb_no_tls() {
   echo_step "Installing PostgresDB into default namespace"
-  if [[ -z "${postgres_root_pw}" ]]; then
-    postgres_root_pw=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
-  fi
-
-  # Deploy PostgreSQL using official postgres image
-  local yaml="$( cat <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: postgresdb-postgresql
-  namespace: default
-spec:
-  ports:
-  - port: 5432
-    targetPort: 5432
-  selector:
-    app: postgresdb-postgresql
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: postgresdb-postgresql
-  namespace: default
-spec:
-  serviceName: postgresdb-postgresql
-  replicas: 1
-  selector:
-    matchLabels:
-      app: postgresdb-postgresql
-  template:
-    metadata:
-      labels:
-        app: postgresdb-postgresql
-    spec:
-      containers:
-      - name: postgresql
-        image: postgres:18
-        env:
-        - name: POSTGRES_PASSWORD
-          value: "${postgres_root_pw}"
-        ports:
-        - containerPort: 5432
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/postgresql
-        readinessProbe:
-          exec:
-            command:
-            - pg_isready
-            - -U
-            - postgres
-          initialDelaySeconds: 5
-          periodSeconds: 5
-      volumes:
-      - name: data
-        emptyDir: {}
-EOF
-  )"
-  echo "${yaml}" | "${KUBECTL}" apply -f -
-
-  echo_step "Waiting for PostgreSQL to be ready"
-  "${KUBECTL}" wait --for=condition=ready pod -l app=postgresdb-postgresql --timeout=120s
+  postgres_root_pw=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
 
   "${KUBECTL}" create secret generic postgresdb-creds \
       --from-literal username="postgres" \
       --from-literal password="${postgres_root_pw}" \
       --from-literal endpoint="postgresdb-postgresql.default.svc.cluster.local" \
       --from-literal port="5432"
+
+  scriptdir=$(dirname "$0")
+  "${KUBECTL}" apply -f "${scriptdir}/postgres.server.yaml"
+
+  echo_step "Waiting for PostgreSQL to be ready"
+  "${KUBECTL}" wait --for=condition=ready pod -l app=postgresdb-postgresql --timeout=120s
 
   "${KUBECTL}" port-forward --namespace default svc/postgresdb-postgresql 5432:5432 &
   PORT_FORWARD_PID=$!
@@ -83,60 +28,42 @@ EOF
 
 setup_provider_config_postgres_no_tls() {
   echo_step "creating ProviderConfig for PostgresDb with no TLS ${API_TYPE}"
-  ignoreNamespace="" # namespace is required for cluster-scoped resources
-  if [ "${API_TYPE}" = "namespaced" ]; then
-    ignoreNamespace="#"
-  fi
-  local yaml="$( cat <<EOF
-apiVersion: postgresql.sql.${APIGROUP_SUFFIX}crossplane.io/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  sslMode: disable
-  credentials:
-    source: PostgreSQLConnectionSecret
-    connectionSecretRef:
-      ${ignoreNamespace}namespace: default
-      name: postgresdb-creds
-EOF
-  )"
-  echo "${yaml}" | "${KUBECTL}" apply -f -
+  "${KUBECTL}" apply -f "${scriptdir}/postgres.providerconfig.${API_TYPE}.yaml"
 }
 
 setup_postgresdb_tests(){
-# install provider resources
-echo_step "creating PostgresDB Database resource"
-# create DB
-"${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/database.yaml
+  # install provider resources
+  echo_step "creating PostgresDB Database resource"
+  # create DB
+  "${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/database.yaml
 
-echo_step "creating PostgresDB Role resource"
-# create grant
-"${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/role.yaml
+  echo_step "creating PostgresDB Role resource"
+  # create grant
+  "${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/role.yaml
 
-echo_step "creating PostgresDB Grant resource"
-# create grant
-"${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/grant.yaml
+  echo_step "creating PostgresDB Grant resource"
+  # create grant
+  "${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/grant.yaml
 
-echo_step "creating PostgresDB Schema resources"
-# create grant
-"${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/schema.yaml
+  echo_step "creating PostgresDB Schema resources"
+  # create grant
+  "${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/postgresql/schema.yaml
 
-echo_step "check if Role is ready"
-"${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/role.yaml > /dev/null
-echo_step_completed
+  echo_step "check if Role is ready"
+  "${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/role.yaml > /dev/null
+  echo_step_completed
 
-echo_step "check if database is ready"
-"${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/database.yaml > /dev/null
-echo_step_completed
+  echo_step "check if database is ready"
+  "${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/database.yaml > /dev/null
+  echo_step_completed
 
-echo_step "check if grant is ready"
-"${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/grant.yaml > /dev/null
-echo_step_completed
+  echo_step "check if grant is ready"
+  "${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/grant.yaml > /dev/null
+  echo_step_completed
 
-echo_step "check if schema is ready"
-"${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/schema.yaml > /dev/null
-echo_step_completed
+  echo_step "check if schema is ready"
+  "${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/postgresql/schema.yaml > /dev/null
+  echo_step_completed
 }
 
 check_all_roles_privileges() {


### PR DESCRIPTION
The helm charts and images are no longer available

https://github.com/bitnami/charts/issues/35164

Switching to plain YAML manifests should get us up and running again and also make changing versions easy and clear, we were using outdated versions.

* mariadb:12
* postgres:18

Fixes #276