### PR TITLE
Add Makefile go.mod.cachedir for release pipeline compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ submodules:
 go.cachedir:
 	@go env GOCACHE
 
+go.mod.cachedir:
+	@go env GOMODCACHE
+
 # NOTE(hasheddan): we must ensure up is installed in tool cache prior to build
 # as including the k8s_tools machinery prior to the xpkg machinery sets UP to
 # point to tool cache.
@@ -131,7 +134,7 @@ dev-clean: $(KIND) $(KUBECTL)
 	@$(INFO) Deleting kind cluster
 	@$(KIND) delete cluster --name=$(PROJECT_NAME)-dev
 
-.PHONY: submodules fallthrough test-integration run crds.clean dev dev-clean
+.PHONY: submodules fallthrough test-integration run crds.clean dev dev-clean go.mod.cachedir go.cachedir
 
 # ====================================================================================
 # Special Targets


### PR DESCRIPTION
### Description of your changes

We only had go.cachedir, provider-kubernetes also had go.mod.cachedir.
This is used here:

https://github.com/crossplane-contrib/provider-workflows/blob/e2da965b49f5bfff36da597dce4737cc30c83c7b/.github/workflows/publish-provider.yml#L110-L114

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes release build: https://github.com/crossplane-contrib/provider-sql/actions/runs/18726280192/job/53411631815

> make: *** No rule to make target 'go.mod.cachedir'.  Stop.

### How has this code been tested

Ran make go.mod.cachedir locally.
