### PR TITLE
chore: Remove tracker and set up type-safe connectors

### DIFF
--- a/pkg/controller/cluster/mssql/grant/reconciler.go
+++ b/pkg/controller/cluster/mssql/grant/reconciler.go
@@ -48,7 +48,6 @@ const (
 	errNoSecretRef  = "ProviderConfig does not reference a credentials Secret"
 	errGetSecret    = "cannot get credentials Secret"
 
-	errNotGrant        = "managed resource is not a Grant custom resource"
 	errGrant           = "cannot grant"
 	errRevoke          = "cannot revoke"
 	errCannotGetGrants = "cannot get current grants"
@@ -56,27 +55,14 @@ const (
 	maxConcurrency = 5
 )
 
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.LegacyProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.LegacyManaged))
-}
-
 // Setup adds a controller that reconciles Grant managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.GrantGroupKind)
 
-	// This can only be a legacy tracker
 	t := resource.NewLegacyProviderConfigUsageTracker(mgr.GetClient(), &v1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newClient: mssql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newClient: mssql.New}),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
@@ -100,26 +86,21 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube      client.Client
-	usage     resource.Tracker
+	track     func(ctx context.Context, mg resource.LegacyManaged) error
 	newClient func(creds map[string][]byte, database string) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*v1alpha1.Grant] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return nil, errors.New(errNotGrant)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *v1alpha1.Grant) (managed.TypedExternalClient[*v1alpha1.Grant], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
 	pc := &v1alpha1.ProviderConfig{}
-	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {
 		return nil, errors.Wrap(err, errGetPC)
 	}
 
@@ -136,20 +117,15 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.T
 		return nil, errors.Wrap(err, errGetSecret)
 	}
 
-	return &external{db: c.newClient(s.Data, ptr.Deref(cr.Spec.ForProvider.Database, ""))}, nil
+	return &external{db: c.newClient(s.Data, ptr.Deref(mg.Spec.ForProvider.Database, ""))}, nil
 }
 
 type external struct{ db xsql.DB }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*v1alpha1.Grant] = &external{}
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotGrant)
-	}
-
-	permissions, err := c.getPermissions(ctx, cr)
+func (c *external) Observe(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalObservation, error) {
+	permissions, err := c.getPermissions(ctx, mg)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -157,45 +133,35 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, nil
 	}
 
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
-	g, r := diffPermissions(cr.Spec.ForProvider.Permissions.ToStringSlice(), permissions)
+	g, r := diffPermissions(mg.Spec.ForProvider.Permissions.ToStringSlice(), permissions)
 	return managed.ExternalObservation{
 		ResourceExists:   true,
 		ResourceUpToDate: len(g) == 0 && len(r) == 0,
 	}, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotGrant)
-	}
+func (c *external) Create(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalCreation, error) {
+	username := *mg.Spec.ForProvider.User
+	permissions := strings.Join(mg.Spec.ForProvider.Permissions.ToStringSlice(), ", ")
 
-	username := *cr.Spec.ForProvider.User
-	permissions := strings.Join(cr.Spec.ForProvider.Permissions.ToStringSlice(), ", ")
-
-	query := fmt.Sprintf("GRANT %s %s TO %s", permissions, onSchemaQuery(cr), mssql.QuoteIdentifier(username))
+	query := fmt.Sprintf("GRANT %s %s TO %s", permissions, onSchemaQuery(mg), mssql.QuoteIdentifier(username))
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: query}), errGrant)
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalUpdate{}, errors.New(errNotGrant)
-	}
-
-	observed, err := c.getPermissions(ctx, cr)
+func (c *external) Update(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalUpdate, error) {
+	observed, err := c.getPermissions(ctx, mg)
 	if err != nil {
 		return managed.ExternalUpdate{}, err
 	}
-	desired := cr.Spec.ForProvider.Permissions.ToStringSlice()
+	desired := mg.Spec.ForProvider.Permissions.ToStringSlice()
 	toGrant, toRevoke := diffPermissions(desired, observed)
 
 	if len(toRevoke) > 0 {
 		sort.Strings(toRevoke)
 		query := fmt.Sprintf("REVOKE %s %s FROM %s",
-			strings.Join(toRevoke, ", "), onSchemaQuery(cr), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
+			strings.Join(toRevoke, ", "), onSchemaQuery(mg), mssql.QuoteIdentifier(*mg.Spec.ForProvider.User))
 		if err = c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errRevoke)
 		}
@@ -203,7 +169,7 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if len(toGrant) > 0 {
 		sort.Strings(toGrant)
 		query := fmt.Sprintf("GRANT %s %s TO %s",
-			strings.Join(toGrant, ", "), onSchemaQuery(cr), mssql.QuoteIdentifier(*cr.Spec.ForProvider.User))
+			strings.Join(toGrant, ", "), onSchemaQuery(mg), mssql.QuoteIdentifier(*mg.Spec.ForProvider.User))
 		if err = c.db.Exec(ctx, xsql.Query{String: query}); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errGrant)
 		}
@@ -215,17 +181,12 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotGrant)
-	}
-
-	username := *cr.Spec.ForProvider.User
+func (c *external) Delete(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalDelete, error) {
+	username := *mg.Spec.ForProvider.User
 
 	query := fmt.Sprintf("REVOKE %s %s FROM %s",
-		strings.Join(cr.Spec.ForProvider.Permissions.ToStringSlice(), ", "),
-		onSchemaQuery(cr),
+		strings.Join(mg.Spec.ForProvider.Permissions.ToStringSlice(), ", "),
+		onSchemaQuery(mg),
 		mssql.QuoteIdentifier(username),
 	)
 	return managed.ExternalDelete{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: query}), errRevoke)

--- a/pkg/controller/cluster/mssql/grant/reconciler_test.go
+++ b/pkg/controller/cluster/mssql/grant/reconciler_test.go
@@ -69,16 +69,17 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
+	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.LegacyManaged) error
 		newDB func(creds map[string][]byte, database string) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	cases := map[string]struct {
@@ -87,17 +88,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotGrant),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.LegacyManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Grant{},
@@ -110,7 +104,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -132,7 +126,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -159,7 +153,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -176,7 +170,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newClient: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newClient: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -194,7 +188,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -208,15 +202,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"SuccessNoGrant": {
 			reason: "We should return ResourceExists: false when no grant is found",
 			fields: fields{
@@ -421,7 +406,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -435,15 +420,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the grant should be returned",
 			fields: fields{
@@ -545,7 +521,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -559,15 +535,6 @@ func TestUpdate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while updating the grant should be returned",
 			fields: fields{
@@ -689,7 +656,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	cases := map[string]struct {
@@ -698,13 +665,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotGrant),
-		},
 		"ErrDropGrant": {
 			reason: "Errors dropping a grant should be returned",
 			fields: fields{

--- a/pkg/controller/cluster/mssql/user/reconciler_test.go
+++ b/pkg/controller/cluster/mssql/user/reconciler_test.go
@@ -82,16 +82,17 @@ func mockRowsToSQLRows(mockRows *sqlmock.Rows) *sql.Rows {
 
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
+	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.LegacyManaged) error
 		newDB func(creds map[string][]byte, database string) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -105,19 +106,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.LegacyManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.User{},
@@ -132,7 +124,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -156,7 +148,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -185,7 +177,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -217,7 +209,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 				newDB: func(creds map[string][]byte, database string) xsql.DB { return mockDB{database: database} },
 			},
 			args: args{
@@ -254,7 +246,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 				newDB: func(creds map[string][]byte, database string) xsql.DB { return mockDB{database: database} },
 			},
 			args: args{
@@ -279,7 +271,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newClient: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newClient: tc.fields.newDB}
 			ec, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -310,7 +302,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -324,15 +316,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrNoUser": {
 			reason: "We should return ResourceExists: false when no user is found",
 			fields: fields{
@@ -454,7 +437,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -469,15 +452,6 @@ func TestCreate(t *testing.T) {
 		args      args
 		want      want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the user should be returned",
 			fields: fields{
@@ -607,7 +581,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx  context.Context
-		mg   resource.Managed
+		mg   *v1alpha1.User
 		kube client.Client
 	}
 
@@ -622,15 +596,6 @@ func TestUpdate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while updating the user should be returned",
 			fields: fields{
@@ -823,7 +788,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	cases := map[string]struct {
@@ -832,13 +797,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotUser),
-		},
 		"ErrDropDB": {
 			reason: "Errors dropping a user should be returned",
 			fields: fields{

--- a/pkg/controller/cluster/mysql/database/reconciler_test.go
+++ b/pkg/controller/cluster/mysql/database/reconciler_test.go
@@ -60,16 +60,17 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
+	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.LegacyManaged) error
 		newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -78,17 +79,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.LegacyManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Database{},
@@ -101,7 +95,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -123,7 +117,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -150,7 +144,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -167,7 +161,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newDB: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newDB: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -185,7 +179,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -199,15 +193,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrNoDatabase": {
 			reason: "We should return ResourceExists: false when no database is found",
 			fields: fields{
@@ -280,7 +265,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -294,15 +279,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the database should be returned",
 			fields: fields{
@@ -356,7 +332,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -365,13 +341,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrDropDB": {
 			reason: "Errors dropping a database should be returned",
 			fields: fields{

--- a/pkg/controller/cluster/mysql/grant/reconciler.go
+++ b/pkg/controller/cluster/mysql/grant/reconciler.go
@@ -51,7 +51,6 @@ const (
 	errGetSecret    = "cannot get credentials Secret"
 	errTLSConfig    = "cannot load TLS config"
 
-	errNotGrant     = "managed resource is not a Grant custom resource"
 	errCreateGrant  = "cannot create grant"
 	errRevokeGrant  = "cannot revoke grant"
 	errCurrentGrant = "cannot show current grants"
@@ -65,27 +64,13 @@ var (
 	grantRegex = regexp.MustCompile(`^GRANT (.+) ON (\S+)\.(\S+) TO \S+@\S+?(\sWITH GRANT OPTION)?$`)
 )
 
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.LegacyProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.LegacyManaged))
-}
-
 // Setup adds a controller that reconciles Grant managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.GrantGroupKind)
-
-	// This can only be a legacy tracker
 	t := resource.NewLegacyProviderConfigUsageTracker(mgr.GetClient(), &v1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newDB: mysql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newDB: mysql.New}),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
@@ -109,25 +94,20 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube  client.Client
-	usage resource.Tracker
+	track func(ctx context.Context, mg resource.LegacyManaged) error
 	newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*v1alpha1.Grant] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return nil, errors.New(errNotGrant)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *v1alpha1.Grant) (managed.TypedExternalClient[*v1alpha1.Grant], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
-	providerConfigName := cr.GetProviderConfigReference().Name
+	providerConfigName := mg.GetProviderConfigReference().Name
 	pc := &v1alpha1.ProviderConfig{}
 	if err := c.kube.Get(ctx, types.NamespacedName{Name: providerConfigName}, pc); err != nil {
 		return nil, errors.Wrap(err, errGetPC)
@@ -151,22 +131,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.T
 		return nil, errors.Wrap(err, errTLSConfig)
 	}
 
-	return &external{db: c.newDB(s.Data, tlsName, cr.Spec.ForProvider.BinLog)}, nil
+	return &external{db: c.newDB(s.Data, tlsName, mg.Spec.ForProvider.BinLog)}, nil
 }
 
 type external struct{ db xsql.DB }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*v1alpha1.Grant] = &external{}
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotGrant)
-	}
-
-	username, host := mysql.SplitUserHost(*cr.Spec.ForProvider.User)
-	dbname := defaultIdentifier(cr.Spec.ForProvider.Database)
-	table := defaultIdentifier(cr.Spec.ForProvider.Table)
+func (c *external) Observe(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalObservation, error) {
+	username, host := mysql.SplitUserHost(*mg.Spec.ForProvider.User)
+	dbname := defaultIdentifier(mg.Spec.ForProvider.Database)
+	table := defaultIdentifier(mg.Spec.ForProvider.Table)
 
 	observedPrivileges, result, err := c.getPrivileges(ctx, username, host, dbname, table)
 	if err != nil {
@@ -176,12 +151,12 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return *result, nil
 	}
 
-	cr.Status.AtProvider.Privileges = observedPrivileges
+	mg.Status.AtProvider.Privileges = observedPrivileges
 
-	desiredPrivileges := cr.Spec.ForProvider.Privileges.ToStringSlice()
+	desiredPrivileges := mg.Spec.ForProvider.Privileges.ToStringSlice()
 	toGrant, toRevoke := diffPermissions(desiredPrivileges, observedPrivileges)
 
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
 	return managed.ExternalObservation{
 		ResourceExists:   true,
@@ -273,17 +248,12 @@ func (c *external) parseGrantRows(ctx context.Context, username, host, dbname, t
 	return privileges, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotGrant)
-	}
+func (c *external) Create(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalCreation, error) {
+	username, host := mysql.SplitUserHost(*mg.Spec.ForProvider.User)
+	dbname := defaultIdentifier(mg.Spec.ForProvider.Database)
+	table := defaultIdentifier(mg.Spec.ForProvider.Table)
 
-	username, host := mysql.SplitUserHost(*cr.Spec.ForProvider.User)
-	dbname := defaultIdentifier(cr.Spec.ForProvider.Database)
-	table := defaultIdentifier(cr.Spec.ForProvider.Table)
-
-	privileges, grantOption := getPrivilegesString(cr.Spec.ForProvider.Privileges.ToStringSlice())
+	privileges, grantOption := getPrivilegesString(mg.Spec.ForProvider.Privileges.ToStringSlice())
 	query := createGrantQuery(privileges, dbname, username, host, table, grantOption)
 
 	if err := mysql.ExecWrapper(ctx, c.db, mysql.ExecQuery{Query: query, ErrorValue: errCreateGrant}); err != nil {
@@ -292,18 +262,13 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	return managed.ExternalCreation{}, nil
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalUpdate{}, errors.New(errNotGrant)
-	}
+func (c *external) Update(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalUpdate, error) {
+	username, host := mysql.SplitUserHost(*mg.Spec.ForProvider.User)
+	dbname := defaultIdentifier(mg.Spec.ForProvider.Database)
+	table := defaultIdentifier(mg.Spec.ForProvider.Table)
 
-	username, host := mysql.SplitUserHost(*cr.Spec.ForProvider.User)
-	dbname := defaultIdentifier(cr.Spec.ForProvider.Database)
-	table := defaultIdentifier(cr.Spec.ForProvider.Table)
-
-	observed := cr.Status.AtProvider.Privileges
-	desired := cr.Spec.ForProvider.Privileges.ToStringSlice()
+	observed := mg.Status.AtProvider.Privileges
+	desired := mg.Spec.ForProvider.Privileges.ToStringSlice()
 	toGrant, toRevoke := diffPermissions(desired, observed)
 
 	if len(toRevoke) > 0 {
@@ -383,17 +348,12 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*v1alpha1.Grant)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotGrant)
-	}
+func (c *external) Delete(ctx context.Context, mg *v1alpha1.Grant) (managed.ExternalDelete, error) {
+	username, host := mysql.SplitUserHost(*mg.Spec.ForProvider.User)
+	dbname := defaultIdentifier(mg.Spec.ForProvider.Database)
+	table := defaultIdentifier(mg.Spec.ForProvider.Table)
 
-	username, host := mysql.SplitUserHost(*cr.Spec.ForProvider.User)
-	dbname := defaultIdentifier(cr.Spec.ForProvider.Database)
-	table := defaultIdentifier(cr.Spec.ForProvider.Table)
-
-	privileges, grantOption := getPrivilegesString(cr.Spec.ForProvider.Privileges.ToStringSlice())
+	privileges, grantOption := getPrivilegesString(mg.Spec.ForProvider.Privileges.ToStringSlice())
 	query := createRevokeQuery(privileges, dbname, username, host, table, grantOption)
 
 	if err := mysql.ExecWrapper(ctx, c.db, mysql.ExecQuery{Query: query, ErrorValue: errRevokeGrant}); err != nil {

--- a/pkg/controller/cluster/mysql/grant/reconciler_test.go
+++ b/pkg/controller/cluster/mysql/grant/reconciler_test.go
@@ -70,16 +70,17 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
+	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.LegacyManaged) error
 		newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	cases := map[string]struct {
@@ -88,17 +89,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotGrant),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.LegacyManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Grant{},
@@ -111,7 +105,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -133,7 +127,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -160,7 +154,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -177,7 +171,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newDB: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newDB: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -195,7 +189,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -210,15 +204,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"SuccessNoGrant": {
 			reason: "We should return ResourceExists: false when no grant is found, being privileges result empty",
 			fields: fields{
@@ -633,7 +618,7 @@ func TestObserve(t *testing.T) {
 			}
 
 			if tc.args.mg != nil {
-				cr, _ := tc.args.mg.(*v1alpha1.Grant)
+				cr := tc.args.mg
 				if diff := cmp.Diff(tc.want.observedPrivileges, cr.Status.AtProvider.Privileges, equateSlices()...); diff != "" {
 					t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
 				}
@@ -651,7 +636,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -665,15 +650,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the grant should be returned",
 			fields: fields{
@@ -798,7 +774,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -812,15 +788,6 @@ func TestUpdate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"ErrExecRevokeNotRequired": {
 			reason: "Any errors encountered while revoking a not required privilege from the desired ones should be returned",
 			fields: fields{
@@ -1041,7 +1008,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	cases := map[string]struct {
@@ -1050,13 +1017,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotGrant),
-		},
 		"ErrDropGrant": {
 			reason: "Errors dropping a grant should be returned",
 			fields: fields{

--- a/pkg/controller/cluster/mysql/user/reconciler.go
+++ b/pkg/controller/cluster/mysql/user/reconciler.go
@@ -50,7 +50,6 @@ const (
 	errGetSecret    = "cannot get credentials Secret"
 	errTLSConfig    = "cannot load TLS config"
 
-	errNotUser                 = "managed resource is not a User custom resource"
 	errSelectUser              = "cannot select user"
 	errCreateUser              = "cannot create user"
 	errDropUser                = "cannot drop user"
@@ -61,27 +60,13 @@ const (
 	maxConcurrency = 5
 )
 
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.LegacyProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.LegacyManaged))
-}
-
 // Setup adds a controller that reconciles User managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.UserGroupKind)
-
-	// This can only be a legacy tracker
 	t := resource.NewLegacyProviderConfigUsageTracker(mgr.GetClient(), &v1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newDB: mysql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newDB: mysql.New}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -104,25 +89,20 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube  client.Client
-	usage resource.Tracker
+	track func(ctx context.Context, mg resource.LegacyManaged) error
 	newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*v1alpha1.User] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*v1alpha1.User)
-	if !ok {
-		return nil, errors.New(errNotUser)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *v1alpha1.User) (managed.TypedExternalClient[*v1alpha1.User], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
-	providerConfigName := cr.GetProviderConfigReference().Name
+	providerConfigName := mg.GetProviderConfigReference().Name
 	pc := &v1alpha1.ProviderConfig{}
 	if err := c.kube.Get(ctx, types.NamespacedName{Name: providerConfigName}, pc); err != nil {
 		return nil, errors.Wrap(err, errGetPC)
@@ -147,7 +127,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.T
 	}
 
 	return &external{
-		db:   c.newDB(s.Data, tlsName, cr.Spec.ForProvider.BinLog),
+		db:   c.newDB(s.Data, tlsName, mg.Spec.ForProvider.BinLog),
 		kube: c.kube,
 	}, nil
 }
@@ -157,7 +137,7 @@ type external struct {
 	kube client.Client
 }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*v1alpha1.User] = &external{}
 
 func handleClause(clause string, value *int, out *[]string) {
 	// If clause is not set (nil pointer), do not push a setting.
@@ -209,13 +189,8 @@ func changedResourceOptions(existing []string, desired []string) ([]string, erro
 	return out, nil
 }
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*v1alpha1.User)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotUser)
-	}
-
-	username, host := mysql.SplitUserHost(meta.GetExternalName(cr))
+func (c *external) Observe(ctx context.Context, mg *v1alpha1.User) (managed.ExternalObservation, error) {
+	username, host := mysql.SplitUserHost(meta.GetExternalName(mg))
 
 	observed := &v1alpha1.UserParameters{
 		ResourceOptions: &v1alpha1.ResourceOptions{},
@@ -247,31 +222,26 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errSelectUser)
 	}
 
-	_, pwdChanged, err := c.getPassword(ctx, cr)
+	_, pwdChanged, err := c.getPassword(ctx, mg)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
 
-	cr.Status.AtProvider.ResourceOptionsAsClauses = resourceOptionsToClauses(observed.ResourceOptions)
+	mg.Status.AtProvider.ResourceOptionsAsClauses = resourceOptionsToClauses(observed.ResourceOptions)
 
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
 	return managed.ExternalObservation{
 		ResourceExists:   true,
-		ResourceUpToDate: !pwdChanged && upToDate(observed, &cr.Spec.ForProvider),
+		ResourceUpToDate: !pwdChanged && upToDate(observed, &mg.Spec.ForProvider),
 	}, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
-	cr, ok := mg.(*v1alpha1.User)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotUser)
-	}
+func (c *external) Create(ctx context.Context, mg *v1alpha1.User) (managed.ExternalCreation, error) {
+	mg.SetConditions(xpv1.Creating())
 
-	cr.SetConditions(xpv1.Creating())
-
-	username, host := mysql.SplitUserHost(meta.GetExternalName(cr))
-	pw, _, err := c.getPassword(ctx, cr)
+	username, host := mysql.SplitUserHost(meta.GetExternalName(mg))
+	pw, _, err := c.getPassword(ctx, mg)
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
@@ -283,13 +253,13 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		}
 	}
 
-	ro := resourceOptionsToClauses(cr.Spec.ForProvider.ResourceOptions)
+	ro := resourceOptionsToClauses(mg.Spec.ForProvider.ResourceOptions)
 	if err := c.executeCreateUserQuery(ctx, username, host, ro, pw); err != nil {
 		return managed.ExternalCreation{}, err
 	}
 
 	if len(ro) != 0 {
-		cr.Status.AtProvider.ResourceOptionsAsClauses = ro
+		mg.Status.AtProvider.ResourceOptionsAsClauses = ro
 	}
 
 	return managed.ExternalCreation{
@@ -318,16 +288,11 @@ func (c *external) executeCreateUserQuery(ctx context.Context, username string, 
 	return nil
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
-	cr, ok := mg.(*v1alpha1.User)
-	if !ok {
-		return managed.ExternalUpdate{}, errors.New(errNotUser)
-	}
+func (c *external) Update(ctx context.Context, mg *v1alpha1.User) (managed.ExternalUpdate, error) {
+	username, host := mysql.SplitUserHost(meta.GetExternalName(mg))
 
-	username, host := mysql.SplitUserHost(meta.GetExternalName(cr))
-
-	ro := resourceOptionsToClauses(cr.Spec.ForProvider.ResourceOptions)
-	rochanged, err := changedResourceOptions(cr.Status.AtProvider.ResourceOptionsAsClauses, ro)
+	ro := resourceOptionsToClauses(mg.Spec.ForProvider.ResourceOptions)
+	rochanged, err := changedResourceOptions(mg.Status.AtProvider.ResourceOptionsAsClauses, ro)
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateUser)
 	}
@@ -345,10 +310,10 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 			return managed.ExternalUpdate{}, err
 		}
 
-		cr.Status.AtProvider.ResourceOptionsAsClauses = ro
+		mg.Status.AtProvider.ResourceOptionsAsClauses = ro
 	}
 
-	connectionDetails, err := c.UpdatePassword(ctx, cr, username, host)
+	connectionDetails, err := c.UpdatePassword(ctx, mg, username, host)
 	if err != nil {
 		return managed.ExternalUpdate{}, err
 	}
@@ -382,15 +347,10 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*v1alpha1.User)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotUser)
-	}
+func (c *external) Delete(ctx context.Context, mg *v1alpha1.User) (managed.ExternalDelete, error) {
+	mg.SetConditions(xpv1.Deleting())
 
-	cr.SetConditions(xpv1.Deleting())
-
-	username, host := mysql.SplitUserHost(meta.GetExternalName(cr))
+	username, host := mysql.SplitUserHost(meta.GetExternalName(mg))
 
 	query := fmt.Sprintf("DROP USER IF EXISTS %s@%s", mysql.QuoteValue(username), mysql.QuoteValue(host))
 	if err := mysql.ExecWrapper(ctx, c.db, mysql.ExecQuery{Query: query, ErrorValue: errDropUser}); err != nil {

--- a/pkg/controller/cluster/postgresql/database/reconciler_test.go
+++ b/pkg/controller/cluster/postgresql/database/reconciler_test.go
@@ -60,16 +60,17 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
+	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.LegacyManaged) error
 		newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -78,17 +79,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.LegacyManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Database{},
@@ -101,7 +95,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -123,7 +117,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -150,7 +144,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -167,7 +161,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newDB: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newDB: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -185,7 +179,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -199,15 +193,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrNoDatabase": {
 			reason: "We should return ResourceExists: false when no database is found",
 			fields: fields{
@@ -280,7 +265,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -294,15 +279,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the database should be returned",
 			fields: fields{
@@ -370,7 +346,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -384,15 +360,6 @@ func TestUpdate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrAlterOwner": {
 			reason: "Errors altering the owner of a database should be returned",
 			fields: fields{
@@ -529,7 +496,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -538,13 +505,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrDropDB": {
 			reason: "Errors dropping a database should be returned",
 			fields: fields{

--- a/pkg/controller/cluster/postgresql/extension/reconciler.go
+++ b/pkg/controller/cluster/postgresql/extension/reconciler.go
@@ -47,7 +47,6 @@ const (
 	errNoSecretRef  = "ProviderConfig does not reference a credentials Secret"
 	errGetSecret    = "cannot get credentials Secret"
 
-	errNotExtension    = "managed resource is not a Extension custom resource"
 	errSelectExtension = "cannot select extension"
 	errCreateExtension = "cannot create extension"
 	errDropExtension   = "cannot drop extension"
@@ -55,27 +54,13 @@ const (
 	maxConcurrency = 5
 )
 
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.LegacyProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.LegacyManaged))
-}
-
 // Setup adds a controller that reconciles Extension managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.ExtensionGroupKind)
-
-	// This can only be a legacy tracker
 	t := resource.NewLegacyProviderConfigUsageTracker(mgr.GetClient(), &v1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newDB: postgresql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newDB: postgresql.New}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -98,26 +83,21 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube  client.Client
-	usage resource.Tracker
+	track func(ctx context.Context, mg resource.LegacyManaged) error
 	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*v1alpha1.Extension] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*v1alpha1.Extension)
-	if !ok {
-		return nil, errors.New(errNotExtension)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *v1alpha1.Extension) (managed.TypedExternalClient[*v1alpha1.Extension], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
 	pc := &v1alpha1.ProviderConfig{}
-	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {
 		return nil, errors.Wrap(err, errGetPC)
 	}
 
@@ -136,8 +116,8 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.T
 
 	// We do not want to create an extension on the default DB
 	// if the user was expecting a database name to be resolved.
-	if cr.Spec.ForProvider.Database != nil {
-		return &external{db: c.newDB(s.Data, *cr.Spec.ForProvider.Database, clients.ToString(pc.Spec.SSLMode))}, nil
+	if mg.Spec.ForProvider.Database != nil {
+		return &external{db: c.newDB(s.Data, *mg.Spec.ForProvider.Database, clients.ToString(pc.Spec.SSLMode))}, nil
 	}
 
 	return &external{db: c.newDB(s.Data, pc.Spec.DefaultDatabase, clients.ToString(pc.Spec.SSLMode))}, nil
@@ -145,14 +125,9 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.T
 
 type external struct{ db xsql.DB }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*v1alpha1.Extension] = &external{}
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*v1alpha1.Extension)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotExtension)
-	}
-
+func (c *external) Observe(ctx context.Context, mg *v1alpha1.Extension) (managed.ExternalObservation, error) {
 	// If the Extension exists, it will have all of these properties.
 	observed := v1alpha1.ExtensionParameters{
 		Version: new(string),
@@ -165,7 +140,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	err := c.db.Scan(ctx, xsql.Query{
 		String:     query,
-		Parameters: []interface{}{cr.Spec.ForProvider.Extension},
+		Parameters: []interface{}{mg.Spec.ForProvider.Extension},
 	},
 		observed.Version,
 	)
@@ -179,39 +154,29 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errSelectExtension)
 	}
 
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceLateInitialized: lateInit(observed, &cr.Spec.ForProvider),
-		ResourceUpToDate:        upToDate(observed, cr.Spec.ForProvider),
+		ResourceLateInitialized: lateInit(observed, &mg.Spec.ForProvider),
+		ResourceUpToDate:        upToDate(observed, mg.Spec.ForProvider),
 	}, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) { //nolint:gocyclo
-	cr, ok := mg.(*v1alpha1.Extension)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotExtension)
-	}
-
+func (c *external) Create(ctx context.Context, mg *v1alpha1.Extension) (managed.ExternalCreation, error) { //nolint:gocyclo
 	var b strings.Builder
 	b.WriteString("CREATE EXTENSION IF NOT EXISTS ")
-	b.WriteString(pq.QuoteIdentifier(cr.Spec.ForProvider.Extension))
+	b.WriteString(pq.QuoteIdentifier(mg.Spec.ForProvider.Extension))
 
-	if cr.Spec.ForProvider.Version != nil {
+	if mg.Spec.ForProvider.Version != nil {
 		b.WriteString(" WITH VERSION ")
-		b.WriteString(pq.QuoteIdentifier(*cr.Spec.ForProvider.Version))
+		b.WriteString(pq.QuoteIdentifier(*mg.Spec.ForProvider.Version))
 	}
 
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: b.String()}), errCreateExtension)
 }
 
-func (c *external) Update(_ context.Context, mg resource.Managed) (managed.ExternalUpdate, error) { //nolint:gocyclo
-	_, ok := mg.(*v1alpha1.Extension)
-	if !ok {
-		return managed.ExternalUpdate{}, errors.New(errNotExtension)
-	}
-
+func (c *external) Update(_ context.Context, mg *v1alpha1.Extension) (managed.ExternalUpdate, error) { //nolint:gocyclo
 	return managed.ExternalUpdate{}, nil
 }
 
@@ -219,13 +184,8 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*v1alpha1.Extension)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotExtension)
-	}
-
-	err := c.db.Exec(ctx, xsql.Query{String: "DROP EXTENSION IF EXISTS " + pq.QuoteIdentifier(cr.Spec.ForProvider.Extension)})
+func (c *external) Delete(ctx context.Context, mg *v1alpha1.Extension) (managed.ExternalDelete, error) {
+	err := c.db.Exec(ctx, xsql.Query{String: "DROP EXTENSION IF EXISTS " + pq.QuoteIdentifier(mg.Spec.ForProvider.Extension)})
 	return managed.ExternalDelete{}, errors.Wrap(err, errDropExtension)
 }
 

--- a/pkg/controller/cluster/postgresql/grant/reconciler_test.go
+++ b/pkg/controller/cluster/postgresql/grant/reconciler_test.go
@@ -70,16 +70,17 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
+	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.LegacyManaged) error
 		newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	cases := map[string]struct {
@@ -88,17 +89,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotGrant),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.LegacyManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Grant{},
@@ -111,7 +105,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -133,7 +127,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -160,7 +154,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Grant{
@@ -177,7 +171,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newDB: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newDB: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -197,7 +191,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -211,15 +205,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"SuccessNoGrant": {
 			reason: "We should return ResourceExists: false when no grant is found",
 			fields: fields{
@@ -407,7 +392,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -421,15 +406,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotGrant),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the grant should be returned",
 			fields: fields{
@@ -497,7 +473,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	type want struct {
@@ -555,7 +531,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Grant
 	}
 
 	cases := map[string]struct {
@@ -564,13 +540,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotGrant": {
-			reason: "An error should be returned if the managed resource is not a *Grant",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotGrant),
-		},
 		"ErrDropGrant": {
 			reason: "Errors dropping a grant should be returned",
 			fields: fields{

--- a/pkg/controller/cluster/postgresql/schema/reconciler_test.go
+++ b/pkg/controller/cluster/postgresql/schema/reconciler_test.go
@@ -66,16 +66,17 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
+	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.LegacyManaged) error
 		newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Schema
 	}
 
 	cr := v1alpha1.Schema{}
@@ -87,17 +88,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotSchema": {
-			reason: "An error should be returned if the managed resource is not a Schema",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotSchema),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.LegacyManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Schema{},
@@ -110,7 +104,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Schema{
@@ -133,7 +127,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Schema{
@@ -161,7 +155,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: nopUsage,
 			},
 			args: args{
 				mg: &v1alpha1.Schema{
@@ -179,7 +173,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newDB: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newDB: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -197,7 +191,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Schema
 	}
 
 	type want struct {
@@ -214,15 +208,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotScema": {
-			reason: "An error should be returned if the managed resource is not a Schema",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotSchema),
-			},
-		},
 		"ErrNoSchema": {
 			reason: "We should return ResourceExists: false when no schema is found",
 			fields: fields{
@@ -344,7 +329,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Schema
 	}
 
 	type want struct {
@@ -358,15 +343,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotSchema": {
-			reason: "An error should be returned if the managed resource is not a Schema",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotSchema),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the schema should be returned",
 			fields: fields{
@@ -430,7 +406,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Schema
 	}
 
 	type want struct {
@@ -444,15 +420,6 @@ func TestUpdate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotSchema": {
-			reason: "An error should be returned if the managed resource is not a Schema",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotSchema),
-			},
-		},
 		"Success": {
 			reason: "No error should be returned when we successfully update a schema",
 			fields: fields{
@@ -502,7 +469,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Schema
 	}
 
 	cases := map[string]struct {
@@ -511,13 +478,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotSchema": {
-			reason: "An error should be returned if the managed resource is not a Schema",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotSchema),
-		},
 		"ErrDropSchema": {
 			reason: "Errors dropping a schema should be returned",
 			fields: fields{

--- a/pkg/controller/namespaced/mssql/database/reconciler_test.go
+++ b/pkg/controller/namespaced/mssql/database/reconciler_test.go
@@ -66,12 +66,12 @@ func TestConnect(t *testing.T) {
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.ModernManaged) error
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -80,17 +80,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Database{},
@@ -100,7 +93,7 @@ func TestConnect(t *testing.T) {
 		"InvalidProviderConfigKind": {
 			reason: "An error should be returned if our ProviderConfig has an invalid kind",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -121,7 +114,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -143,7 +136,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -168,7 +161,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -201,7 +194,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -224,7 +217,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -242,7 +235,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -256,15 +249,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrNoDatabase": {
 			reason: "We should return ResourceExists: false when no database is found",
 			fields: fields{
@@ -337,7 +321,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -351,15 +335,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the database should be returned",
 			fields: fields{
@@ -413,7 +388,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -422,13 +397,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrDropDB": {
 			reason: "Errors dropping a database should be returned",
 			fields: fields{

--- a/pkg/controller/namespaced/mssql/user/reconciler_test.go
+++ b/pkg/controller/namespaced/mssql/user/reconciler_test.go
@@ -88,13 +88,13 @@ func TestConnect(t *testing.T) {
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.ModernManaged) error
 		newDB func(creds map[string][]byte, database string) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -108,19 +108,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.User{},
@@ -132,7 +123,7 @@ func TestConnect(t *testing.T) {
 		"ErrInvalidProviderConfigKind": {
 			reason: "An error should be returned if our ProviderConfigReference kind is invalid",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -153,7 +144,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -180,7 +171,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -207,7 +198,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -242,7 +233,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -280,7 +271,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 				newDB: func(creds map[string][]byte, database string) xsql.DB { return mockDB{database: database} },
 			},
 			args: args{
@@ -323,7 +314,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 				newDB: func(creds map[string][]byte, database string) xsql.DB { return mockDB{database: database} },
 			},
 			args: args{
@@ -354,7 +345,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newClient: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newClient: tc.fields.newDB}
 			ec, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -385,7 +376,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -399,15 +390,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrNoUser": {
 			reason: "We should return ResourceExists: false when no user is found",
 			fields: fields{
@@ -529,7 +511,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -544,15 +526,6 @@ func TestCreate(t *testing.T) {
 		args      args
 		want      want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the user should be returned",
 			fields: fields{
@@ -682,7 +655,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx  context.Context
-		mg   resource.Managed
+		mg   *v1alpha1.User
 		kube client.Client
 	}
 
@@ -697,15 +670,6 @@ func TestUpdate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while updating the user should be returned",
 			fields: fields{
@@ -898,7 +862,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	cases := map[string]struct {
@@ -907,13 +871,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotUser),
-		},
 		"ErrDropDB": {
 			reason: "Errors dropping a user should be returned",
 			fields: fields{

--- a/pkg/controller/namespaced/mysql/database/reconciler.go
+++ b/pkg/controller/namespaced/mysql/database/reconciler.go
@@ -43,34 +43,21 @@ const (
 	errTrackPCUsage = "cannot track ProviderConfig usage"
 	errTLSConfig    = "cannot load TLS config"
 
-	errNotDatabase = "managed resource is not a Database custom resource"
-	errSelectDB    = "cannot select database"
-	errCreateDB    = "cannot create database"
-	errDropDB      = "cannot drop database"
+	errSelectDB = "cannot select database"
+	errCreateDB = "cannot create database"
+	errDropDB   = "cannot drop database"
 
 	maxConcurrency = 5
 )
-
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.ProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.ModernManaged))
-}
 
 // Setup adds a controller that reconciles Database managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(namespacedv1alpha1.DatabaseGroupKind)
 
 	t := resource.NewProviderConfigUsageTracker(mgr.GetClient(), &namespacedv1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newDB: mysql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newDB: mysql.New}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -94,25 +81,20 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube  client.Client
-	usage resource.Tracker
+	track func(ctx context.Context, mg resource.ModernManaged) error
 	newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*namespacedv1alpha1.Database] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return nil, errors.New(errNotDatabase)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.TypedExternalClient[*namespacedv1alpha1.Database], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
-	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, cr)
+	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, mg)
 	if err != nil {
 		return nil, err
 	}
@@ -122,22 +104,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.T
 		return nil, errors.Wrap(err, errTLSConfig)
 	}
 
-	return &external{db: c.newDB(providerInfo.SecretData, tlsName, cr.Spec.ForProvider.BinLog)}, nil
+	return &external{db: c.newDB(providerInfo.SecretData, tlsName, mg.Spec.ForProvider.BinLog)}, nil
 }
 
 type external struct{ db xsql.DB }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*namespacedv1alpha1.Database] = &external{}
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotDatabase)
-	}
-
+func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalObservation, error) {
 	var name string
 	query := "SELECT schema_name FROM information_schema.schemata WHERE schema_name = ?"
-	err := c.db.Scan(ctx, xsql.Query{String: query, Parameters: []interface{}{meta.GetExternalName(cr)}}, &name)
+	err := c.db.Scan(ctx, xsql.Query{String: query, Parameters: []interface{}{meta.GetExternalName(mg)}}, &name)
 	if xsql.IsNoRows(err) {
 		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
@@ -145,7 +122,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errSelectDB)
 	}
 
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
 	return managed.ExternalObservation{
 		ResourceExists: true,
@@ -156,13 +133,8 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotDatabase)
-	}
-
-	query := "CREATE DATABASE " + mysql.QuoteIdentifier(meta.GetExternalName(cr))
+func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalCreation, error) {
+	query := "CREATE DATABASE " + mysql.QuoteIdentifier(meta.GetExternalName(mg))
 
 	if err := mysql.ExecWrapper(ctx, c.db, mysql.ExecQuery{Query: query, ErrorValue: errCreateDB}); err != nil {
 		return managed.ExternalCreation{}, err
@@ -171,7 +143,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	return managed.ExternalCreation{}, nil
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+func (c *external) Update(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalUpdate, error) {
 	// TODO(negz): Support updates once we have anything to update.
 	return managed.ExternalUpdate{}, nil
 }
@@ -180,13 +152,8 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotDatabase)
-	}
-
-	query := "DROP DATABASE IF EXISTS " + mysql.QuoteIdentifier(meta.GetExternalName(cr))
+func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalDelete, error) {
+	query := "DROP DATABASE IF EXISTS " + mysql.QuoteIdentifier(meta.GetExternalName(mg))
 
 	if err := mysql.ExecWrapper(ctx, c.db, mysql.ExecQuery{Query: query, ErrorValue: errDropDB}); err != nil {
 		return managed.ExternalDelete{}, err

--- a/pkg/controller/namespaced/mysql/database/reconciler_test.go
+++ b/pkg/controller/namespaced/mysql/database/reconciler_test.go
@@ -66,13 +66,13 @@ func TestConnect(t *testing.T) {
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.ModernManaged) error
 		newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -81,17 +81,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.Database{},
@@ -101,7 +94,7 @@ func TestConnect(t *testing.T) {
 		"ErrInvalidProviderConfigKind": {
 			reason: "An error should be returned if the ProviderConfig kind is not valid",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -120,7 +113,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -145,7 +138,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -170,7 +163,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -197,7 +190,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.Database{
@@ -217,7 +210,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newDB: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newDB: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -235,7 +228,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -249,15 +242,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrNoDatabase": {
 			reason: "We should return ResourceExists: false when no database is found",
 			fields: fields{
@@ -330,7 +314,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	type want struct {
@@ -344,15 +328,6 @@ func TestCreate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotDatabase),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the database should be returned",
 			fields: fields{
@@ -406,7 +381,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.Database
 	}
 
 	cases := map[string]struct {
@@ -415,13 +390,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotDatabase": {
-			reason: "An error should be returned if the managed resource is not a *Database",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotDatabase),
-		},
 		"ErrDropDB": {
 			reason: "Errors dropping a database should be returned",
 			fields: fields{

--- a/pkg/controller/namespaced/mysql/user/reconciler_test.go
+++ b/pkg/controller/namespaced/mysql/user/reconciler_test.go
@@ -74,13 +74,13 @@ func TestConnect(t *testing.T) {
 
 	type fields struct {
 		kube  client.Client
-		usage resource.Tracker
+		track func(context.Context, resource.ModernManaged) error
 		newDB func(creds map[string][]byte, tls *string, binlog *bool) xsql.DB
 	}
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	cases := map[string]struct {
@@ -89,17 +89,10 @@ func TestConnect(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotUser),
-		},
 		"ErrTrackProviderConfigUsage": {
 			reason: "An error should be returned if we can't track our ProviderConfig usage",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return errBoom }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return errBoom },
 			},
 			args: args{
 				mg: &v1alpha1.User{},
@@ -109,7 +102,7 @@ func TestConnect(t *testing.T) {
 		"ErrInvalidProviderConfigKind": {
 			reason: "An error should be returned if the ProviderConfig kind is not valid",
 			fields: fields{
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -128,7 +121,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -150,7 +143,7 @@ func TestConnect(t *testing.T) {
 				kube: &test.MockClient{
 					MockGet: test.NewMockGetFn(errBoom),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -175,7 +168,7 @@ func TestConnect(t *testing.T) {
 					// in a ProviderConfig with a nil connection secret.
 					MockGet: test.NewMockGetFn(nil),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -208,7 +201,7 @@ func TestConnect(t *testing.T) {
 						return nil
 					}),
 				},
-				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),
+				track: func(ctx context.Context, mg resource.ModernManaged) error { return nil },
 			},
 			args: args{
 				mg: &v1alpha1.User{
@@ -229,7 +222,7 @@ func TestConnect(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &connector{kube: tc.fields.kube, usage: tc.fields.usage, newDB: tc.fields.newDB}
+			e := &connector{kube: tc.fields.kube, track: tc.fields.track, newDB: tc.fields.newDB}
 			_, err := e.Connect(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Connect(...): -want error, +got error:\n%s\n", tc.reason, diff)
@@ -248,7 +241,7 @@ func TestObserve(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -262,15 +255,6 @@ func TestObserve(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrNoUser": {
 			reason: "We should return ResourceExists: false when no user is found",
 			fields: fields{
@@ -398,7 +382,7 @@ func TestCreate(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	type want struct {
@@ -413,15 +397,6 @@ func TestCreate(t *testing.T) {
 		args      args
 		want      want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while creating the user should be returned",
 			fields: fields{
@@ -587,7 +562,7 @@ func TestUpdate(t *testing.T) {
 
 	type args struct {
 		ctx  context.Context
-		mg   resource.Managed
+		mg   *v1alpha1.User
 		kube client.Client
 	}
 
@@ -602,15 +577,6 @@ func TestUpdate(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: want{
-				err: errors.New(errNotUser),
-			},
-		},
 		"ErrExec": {
 			reason: "Any errors encountered while updating the user should be returned",
 			fields: fields{
@@ -869,7 +835,7 @@ func TestDelete(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		mg  resource.Managed
+		mg  *v1alpha1.User
 	}
 
 	cases := map[string]struct {
@@ -878,13 +844,6 @@ func TestDelete(t *testing.T) {
 		args   args
 		want   error
 	}{
-		"ErrNotUser": {
-			reason: "An error should be returned if the managed resource is not a *User",
-			args: args{
-				mg: nil,
-			},
-			want: errors.New(errNotUser),
-		},
 		"ErrDropUser": {
 			reason: "Errors dropping a user should be returned",
 			fields: fields{

--- a/pkg/controller/namespaced/postgresql/database/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/database/reconciler.go
@@ -47,7 +47,6 @@ import (
 const (
 	errTrackPCUsage = "cannot track ProviderConfig usage"
 
-	errNotDatabase       = "managed resource is not a Database custom resource"
 	errSelectDB          = "cannot select database"
 	errCreateDB          = "cannot create database"
 	errAlterDBOwner      = "cannot alter database owner"
@@ -59,26 +58,14 @@ const (
 	maxConcurrency = 5
 )
 
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.ProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.ModernManaged))
-}
-
 // Setup adds a controller that reconciles Database managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(namespacedv1alpha1.DatabaseGroupKind)
 
 	t := resource.NewProviderConfigUsageTracker(mgr.GetClient(), &namespacedv1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newDB: postgresql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newDB: postgresql.New}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -101,25 +88,20 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube  client.Client
-	usage resource.Tracker
+	track func(ctx context.Context, mg resource.ModernManaged) error
 	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*namespacedv1alpha1.Database] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return nil, errors.New(errNotDatabase)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.TypedExternalClient[*namespacedv1alpha1.Database], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
-	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, cr)
+	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, mg)
 	if err != nil {
 		return nil, err
 	}
@@ -129,14 +111,9 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.T
 
 type external struct{ db xsql.DB }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*namespacedv1alpha1.Database] = &external{}
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotDatabase)
-	}
-
+func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalObservation, error) {
 	// If the database exists, it will have all of these properties.
 	observed := namespacedv1alpha1.DatabaseParameters{
 		Owner:            new(string),
@@ -161,7 +138,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		"FROM pg_database AS db, pg_tablespace AS ts " +
 		"WHERE db.datname=$1 AND db.dattablespace = ts.oid"
 
-	err := c.db.Scan(ctx, xsql.Query{String: query, Parameters: []interface{}{meta.GetExternalName(cr)}},
+	err := c.db.Scan(ctx, xsql.Query{String: query, Parameters: []interface{}{meta.GetExternalName(mg)}},
 		observed.Owner,
 		observed.Encoding,
 		observed.LCCollate,
@@ -178,7 +155,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errSelectDB)
 	}
 
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
 	return managed.ExternalObservation{
 		ResourceExists: true,
@@ -186,101 +163,91 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		// NOTE(negz): The ordering is important here. We want to late init any
 		// values that weren't supplied before we determine if an update is
 		// required.
-		ResourceLateInitialized: lateInit(observed, &cr.Spec.ForProvider),
-		ResourceUpToDate:        upToDate(observed, cr.Spec.ForProvider),
+		ResourceLateInitialized: lateInit(observed, &mg.Spec.ForProvider),
+		ResourceUpToDate:        upToDate(observed, mg.Spec.ForProvider),
 	}, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) { //nolint:gocyclo
+func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalCreation, error) { //nolint:gocyclo
 	// NOTE(negz): This is only a tiny bit over our cyclomatic complexity limit,
 	// and more readable than if we refactored it to avoid the linter error.
 
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotDatabase)
-	}
-
 	var b strings.Builder
 	b.WriteString("CREATE DATABASE ")
-	b.WriteString(pq.QuoteIdentifier(meta.GetExternalName(cr)))
+	b.WriteString(pq.QuoteIdentifier(meta.GetExternalName(mg)))
 
-	if cr.Spec.ForProvider.Owner != nil {
+	if mg.Spec.ForProvider.Owner != nil {
 		b.WriteString(" OWNER ")
-		b.WriteString(pq.QuoteIdentifier(*cr.Spec.ForProvider.Owner))
+		b.WriteString(pq.QuoteIdentifier(*mg.Spec.ForProvider.Owner))
 	}
-	if cr.Spec.ForProvider.Template != nil {
+	if mg.Spec.ForProvider.Template != nil {
 		b.WriteString(" TEMPLATE ")
-		b.WriteString(quoteIfIdentifier(*cr.Spec.ForProvider.Template))
+		b.WriteString(quoteIfIdentifier(*mg.Spec.ForProvider.Template))
 	}
-	if cr.Spec.ForProvider.Encoding != nil {
+	if mg.Spec.ForProvider.Encoding != nil {
 		b.WriteString(" ENCODING ")
-		b.WriteString(quoteIfLiteral(*cr.Spec.ForProvider.Encoding))
+		b.WriteString(quoteIfLiteral(*mg.Spec.ForProvider.Encoding))
 	}
-	if cr.Spec.ForProvider.LCCollate != nil {
+	if mg.Spec.ForProvider.LCCollate != nil {
 		b.WriteString(" LC_COLLATE ")
-		b.WriteString(quoteIfLiteral(*cr.Spec.ForProvider.LCCollate))
+		b.WriteString(quoteIfLiteral(*mg.Spec.ForProvider.LCCollate))
 	}
-	if cr.Spec.ForProvider.LCCType != nil {
+	if mg.Spec.ForProvider.LCCType != nil {
 		b.WriteString(" LC_CTYPE ")
-		b.WriteString(quoteIfLiteral(*cr.Spec.ForProvider.LCCType))
+		b.WriteString(quoteIfLiteral(*mg.Spec.ForProvider.LCCType))
 	}
-	if cr.Spec.ForProvider.Tablespace != nil {
+	if mg.Spec.ForProvider.Tablespace != nil {
 		b.WriteString(" TABLESPACE ")
-		b.WriteString(quoteIfIdentifier(*cr.Spec.ForProvider.Tablespace))
+		b.WriteString(quoteIfIdentifier(*mg.Spec.ForProvider.Tablespace))
 	}
-	if cr.Spec.ForProvider.AllowConnections != nil {
-		b.WriteString(fmt.Sprintf(" ALLOW_CONNECTIONS %t", *cr.Spec.ForProvider.AllowConnections))
+	if mg.Spec.ForProvider.AllowConnections != nil {
+		b.WriteString(fmt.Sprintf(" ALLOW_CONNECTIONS %t", *mg.Spec.ForProvider.AllowConnections))
 	}
-	if cr.Spec.ForProvider.ConnectionLimit != nil {
-		b.WriteString(fmt.Sprintf(" CONNECTION LIMIT %d", *cr.Spec.ForProvider.ConnectionLimit))
+	if mg.Spec.ForProvider.ConnectionLimit != nil {
+		b.WriteString(fmt.Sprintf(" CONNECTION LIMIT %d", *mg.Spec.ForProvider.ConnectionLimit))
 	}
-	if cr.Spec.ForProvider.IsTemplate != nil {
-		b.WriteString(fmt.Sprintf(" IS_TEMPLATE %t", *cr.Spec.ForProvider.IsTemplate))
+	if mg.Spec.ForProvider.IsTemplate != nil {
+		b.WriteString(fmt.Sprintf(" IS_TEMPLATE %t", *mg.Spec.ForProvider.IsTemplate))
 	}
 
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: b.String()}), errCreateDB)
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) { //nolint:gocyclo
+func (c *external) Update(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalUpdate, error) { //nolint:gocyclo
 	// NOTE(negz): This is only a tiny bit over our cyclomatic complexity limit,
 	// and more readable than if we refactored it to avoid the linter error.
 
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return managed.ExternalUpdate{}, errors.New(errNotDatabase)
-	}
-
-	if cr.Spec.ForProvider.Owner != nil {
+	if mg.Spec.ForProvider.Owner != nil {
 		query := xsql.Query{String: fmt.Sprintf("ALTER DATABASE %s OWNER TO %s",
-			pq.QuoteIdentifier(meta.GetExternalName(cr)),
-			pq.QuoteIdentifier(*cr.Spec.ForProvider.Owner))}
+			pq.QuoteIdentifier(meta.GetExternalName(mg)),
+			pq.QuoteIdentifier(*mg.Spec.ForProvider.Owner))}
 		if err := c.db.Exec(ctx, query); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errAlterDBOwner)
 		}
 	}
 
-	if cr.Spec.ForProvider.ConnectionLimit != nil {
+	if mg.Spec.ForProvider.ConnectionLimit != nil {
 		query := xsql.Query{String: fmt.Sprintf("ALTER DATABASE %s CONNECTION LIMIT = %d",
-			pq.QuoteIdentifier(meta.GetExternalName(cr)),
-			*cr.Spec.ForProvider.ConnectionLimit)}
+			pq.QuoteIdentifier(meta.GetExternalName(mg)),
+			*mg.Spec.ForProvider.ConnectionLimit)}
 		if err := c.db.Exec(ctx, query); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errAlterDBConnLimit)
 		}
 	}
 
-	if cr.Spec.ForProvider.AllowConnections != nil {
+	if mg.Spec.ForProvider.AllowConnections != nil {
 		query := xsql.Query{String: fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS %t",
-			pq.QuoteIdentifier(meta.GetExternalName(cr)),
-			*cr.Spec.ForProvider.AllowConnections)}
+			pq.QuoteIdentifier(meta.GetExternalName(mg)),
+			*mg.Spec.ForProvider.AllowConnections)}
 		if err := c.db.Exec(ctx, query); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errAlterDBAllowConns)
 		}
 	}
 
-	if cr.Spec.ForProvider.IsTemplate != nil {
+	if mg.Spec.ForProvider.IsTemplate != nil {
 		query := xsql.Query{String: fmt.Sprintf("ALTER DATABASE %s IS_TEMPLATE %t",
-			pq.QuoteIdentifier(meta.GetExternalName(cr)),
-			*cr.Spec.ForProvider.IsTemplate)}
+			pq.QuoteIdentifier(meta.GetExternalName(mg)),
+			*mg.Spec.ForProvider.IsTemplate)}
 		if err := c.db.Exec(ctx, query); err != nil {
 			return managed.ExternalUpdate{}, errors.Wrap(err, errAlterDBIsTmpl)
 		}
@@ -293,13 +260,8 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Database)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotDatabase)
-	}
-
-	err := c.db.Exec(ctx, xsql.Query{String: "DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(cr))})
+func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalDelete, error) {
+	err := c.db.Exec(ctx, xsql.Query{String: "DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(mg))})
 	return managed.ExternalDelete{}, errors.Wrap(err, errDropDB)
 }
 

--- a/pkg/controller/namespaced/postgresql/grant/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/grant/reconciler.go
@@ -44,7 +44,6 @@ import (
 const (
 	errTrackPCUsage = "cannot track ProviderConfig usage"
 
-	errNotGrant     = "managed resource is not a Grant custom resource"
 	errSelectGrant  = "cannot select grant"
 	errCreateGrant  = "cannot create grant"
 	errRevokeGrant  = "cannot revoke grant"
@@ -60,26 +59,14 @@ const (
 	maxConcurrency = 5
 )
 
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.ProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.ModernManaged))
-}
-
 // Setup adds a controller that reconciles Database managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(namespacedv1alpha1.GrantGroupKind)
 
 	t := resource.NewProviderConfigUsageTracker(mgr.GetClient(), &namespacedv1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newDB: postgresql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newDB: postgresql.New}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -102,25 +89,20 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube  client.Client
-	usage resource.Tracker
+	track func(ctx context.Context, mg resource.ModernManaged) error
 	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*namespacedv1alpha1.Grant] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*namespacedv1alpha1.Grant)
-	if !ok {
-		return nil, errors.New(errNotGrant)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *namespacedv1alpha1.Grant) (managed.TypedExternalClient[*namespacedv1alpha1.Grant], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
-	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, cr)
+	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, mg)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +118,7 @@ type external struct {
 	kube client.Client
 }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*namespacedv1alpha1.Grant] = &external{}
 
 type grantType string
 
@@ -323,17 +305,12 @@ func deleteGrantQuery(gp namespacedv1alpha1.GrantParameters, q *xsql.Query) erro
 	return errors.New(errUnknownGrant)
 }
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Grant)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotGrant)
-	}
-
-	if cr.Spec.ForProvider.Role == nil {
+func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Grant) (managed.ExternalObservation, error) {
+	if mg.Spec.ForProvider.Role == nil {
 		return managed.ExternalObservation{}, errors.New(errNoRole)
 	}
 
-	gp := cr.Spec.ForProvider
+	gp := mg.Spec.ForProvider
 	var query xsql.Query
 	if err := selectGrantQuery(gp, &query); err != nil {
 		return managed.ExternalObservation{}, err
@@ -350,7 +327,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	// Grants have no way of being 'not up to date' - if they exist, they are up to date
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
@@ -359,17 +336,12 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Grant)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotGrant)
-	}
-
+func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Grant) (managed.ExternalCreation, error) {
 	var queries []xsql.Query
 
-	cr.SetConditions(xpv1.Creating())
+	mg.SetConditions(xpv1.Creating())
 
-	if err := createGrantQueries(cr.Spec.ForProvider, &queries); err != nil {
+	if err := createGrantQueries(mg.Spec.ForProvider, &queries); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateGrant)
 	}
 
@@ -377,7 +349,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	return managed.ExternalCreation{}, errors.Wrap(err, errCreateGrant)
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+func (c *external) Update(ctx context.Context, mg *namespacedv1alpha1.Grant) (managed.ExternalUpdate, error) {
 	// Update is a no-op, as permissions are fully revoked and then granted in the Create function,
 	// inside a transaction.
 	return managed.ExternalUpdate{}, nil
@@ -387,16 +359,12 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Grant)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotGrant)
-	}
+func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Grant) (managed.ExternalDelete, error) {
 	var query xsql.Query
 
-	cr.SetConditions(xpv1.Deleting())
+	mg.SetConditions(xpv1.Deleting())
 
-	err := deleteGrantQuery(cr.Spec.ForProvider, &query)
+	err := deleteGrantQuery(mg.Spec.ForProvider, &query)
 	if err != nil {
 		return managed.ExternalDelete{}, errors.Wrap(err, errRevokeGrant)
 	}

--- a/pkg/controller/namespaced/postgresql/role/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/role/reconciler.go
@@ -49,7 +49,6 @@ import (
 const (
 	errTrackPCUsage = "cannot track ProviderConfig usage"
 
-	errNotRole                 = "managed resource is not a Role custom resource"
 	errSelectRole              = "cannot select role"
 	errCreateRole              = "cannot create role"
 	errDropRole                = "cannot drop role"
@@ -61,26 +60,14 @@ const (
 	maxConcurrency = 5
 )
 
-// TODO(nateinaction): This looks wrong, can tracker creation be improved?
-type tracker struct {
-	tracker *resource.ProviderConfigUsageTracker
-}
-
-var _ resource.Tracker = &tracker{}
-
-func (t *tracker) Track(ctx context.Context, mg resource.Managed) error {
-	return t.tracker.Track(ctx, mg.(resource.ModernManaged))
-}
-
 // Setup adds a controller that reconciles Database managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(namespacedv1alpha1.RoleGroupKind)
 
 	t := resource.NewProviderConfigUsageTracker(mgr.GetClient(), &namespacedv1alpha1.ProviderConfigUsage{})
-	trk := &tracker{tracker: t}
 
 	reconcilerOptions := []managed.ReconcilerOption{
-		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), usage: trk, newDB: postgresql.New}),
+		managed.WithTypedExternalConnector(&connector{kube: mgr.GetClient(), track: t.Track, newDB: postgresql.New}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -103,25 +90,20 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube  client.Client
-	usage resource.Tracker
+	track func(ctx context.Context, mg resource.ModernManaged) error
 	newDB func(creds map[string][]byte, database string, sslmode string) xsql.DB
 }
 
-var _ managed.TypedExternalConnector[resource.Managed] = &connector{}
+var _ managed.TypedExternalConnector[*namespacedv1alpha1.Role] = &connector{}
 
-func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.TypedExternalClient[resource.Managed], error) {
-	cr, ok := mg.(*namespacedv1alpha1.Role)
-	if !ok {
-		return nil, errors.New(errNotRole)
-	}
-
-	if err := c.usage.Track(ctx, mg); err != nil {
+func (c *connector) Connect(ctx context.Context, mg *namespacedv1alpha1.Role) (managed.TypedExternalClient[*namespacedv1alpha1.Role], error) {
+	if err := c.track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
 	// ProviderConfigReference could theoretically be nil, but in practice the
 	// DefaultProviderConfig initializer will set it before we get here.
-	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, cr)
+	providerInfo, err := provider.GetProviderConfig(ctx, c.kube, mg)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +119,7 @@ type external struct {
 	kube client.Client
 }
 
-var _ managed.TypedExternalClient[resource.Managed] = &external{}
+var _ managed.TypedExternalClient[*namespacedv1alpha1.Role] = &external{}
 
 func negateClause(clause string, negate *bool, out *[]string) {
 	// If clause boolean is not set (nil pointer), do not push a setting.
@@ -191,12 +173,7 @@ func changedPrivs(existing []string, desired []string) ([]string, error) {
 	return out, nil
 }
 
-func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Role)
-	if !ok {
-		return managed.ExternalObservation{}, errors.New(errNotRole)
-	}
-
+func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Role) (managed.ExternalObservation, error) {
 	observed := &namespacedv1alpha1.RoleParameters{
 		Privileges: namespacedv1alpha1.RolePrivilege{
 			SuperUser:   new(bool),
@@ -226,7 +203,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		xsql.Query{
 			String: query,
 			Parameters: []interface{}{
-				meta.GetExternalName(cr),
+				meta.GetExternalName(mg),
 			},
 		},
 		&observed.Privileges.SuperUser,
@@ -257,37 +234,32 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		}
 		observed.ConfigurationParameters = &rc
 	}
-	cr.Status.AtProvider.ConfigurationParameters = observed.ConfigurationParameters
+	mg.Status.AtProvider.ConfigurationParameters = observed.ConfigurationParameters
 
-	_, pwdChanged, err := c.getPassword(ctx, cr)
+	_, pwdChanged, err := c.getPassword(ctx, mg)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
 
-	cr.SetConditions(xpv1.Available())
+	mg.SetConditions(xpv1.Available())
 
 	// PrivilegesAsClauses is used as role status output
-	cr.Status.AtProvider.PrivilegesAsClauses = privilegesToClauses(observed.Privileges)
+	mg.Status.AtProvider.PrivilegesAsClauses = privilegesToClauses(observed.Privileges)
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceLateInitialized: lateInit(observed, &cr.Spec.ForProvider),
-		ResourceUpToDate:        !pwdChanged && upToDate(observed, &cr.Spec.ForProvider),
+		ResourceLateInitialized: lateInit(observed, &mg.Spec.ForProvider),
+		ResourceUpToDate:        !pwdChanged && upToDate(observed, &mg.Spec.ForProvider),
 	}, nil
 }
 
-func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Role)
-	if !ok {
-		return managed.ExternalCreation{}, errors.New(errNotRole)
-	}
+func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Role) (managed.ExternalCreation, error) {
+	mg.SetConditions(xpv1.Creating())
 
-	cr.SetConditions(xpv1.Creating())
+	crn := pq.QuoteIdentifier(meta.GetExternalName(mg))
+	privs := privilegesToClauses(mg.Spec.ForProvider.Privileges)
 
-	crn := pq.QuoteIdentifier(meta.GetExternalName(cr))
-	privs := privilegesToClauses(cr.Spec.ForProvider.Privileges)
-
-	pw, _, err := c.getPassword(ctx, cr)
+	pw, _, err := c.getPassword(ctx, mg)
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
@@ -315,39 +287,35 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	// PrivilegesAsClauses is used as role status output
 	// Update here so that state is reflected to the user prior to the next
 	// reconciler loop.
-	cr.Status.AtProvider.PrivilegesAsClauses = privs
-	if cr.Spec.ForProvider.ConfigurationParameters != nil {
-		for _, v := range *cr.Spec.ForProvider.ConfigurationParameters {
+	mg.Status.AtProvider.PrivilegesAsClauses = privs
+	if mg.Spec.ForProvider.ConfigurationParameters != nil {
+		for _, v := range *mg.Spec.ForProvider.ConfigurationParameters {
 			if err := c.db.Exec(ctx, xsql.Query{
 				String: fmt.Sprintf("ALTER ROLE %s set %s=%s", crn, pq.QuoteIdentifier(v.Name), pq.QuoteIdentifier(v.Value)),
 			}); err != nil {
 				return managed.ExternalCreation{}, errors.Wrap(err, errSetRoleConfigs)
 			}
 		}
-		cr.Status.AtProvider.ConfigurationParameters = cr.Spec.ForProvider.ConfigurationParameters
+		mg.Status.AtProvider.ConfigurationParameters = mg.Spec.ForProvider.ConfigurationParameters
 	}
 
 	return managed.ExternalCreation{
-		ConnectionDetails: c.db.GetConnectionDetails(meta.GetExternalName(cr), pw),
+		ConnectionDetails: c.db.GetConnectionDetails(meta.GetExternalName(mg), pw),
 	}, nil
 }
 
-func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) { //nolint:gocyclo
+func (c *external) Update(ctx context.Context, mg *namespacedv1alpha1.Role) (managed.ExternalUpdate, error) { //nolint:gocyclo
 	// NOTE(benagricola): This is just a touch over the cyclomatic complexity
 	// limit, but is unlikely to become more complex unless new role features
 	// are added. Think about splitting this method up if new functionality
 	// is desired.
-	cr, ok := mg.(*namespacedv1alpha1.Role)
-	if !ok {
-		return managed.ExternalUpdate{}, errors.New(errNotRole)
-	}
 
-	pw, pwchanged, err := c.getPassword(ctx, cr)
+	pw, pwchanged, err := c.getPassword(ctx, mg)
 	if err != nil {
 		return managed.ExternalUpdate{}, err
 	}
 
-	crn := pq.QuoteIdentifier(meta.GetExternalName(cr))
+	crn := pq.QuoteIdentifier(meta.GetExternalName(mg))
 
 	if pwchanged {
 		if err := c.db.Exec(ctx, xsql.Query{
@@ -357,8 +325,8 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		}
 	}
 
-	privs := privilegesToClauses(cr.Spec.ForProvider.Privileges)
-	cp, err := changedPrivs(cr.Status.AtProvider.PrivilegesAsClauses, privs)
+	privs := privilegesToClauses(mg.Spec.ForProvider.Privileges)
+	cp, err := changedPrivs(mg.Status.AtProvider.PrivilegesAsClauses, privs)
 
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateRole)
@@ -375,18 +343,18 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	// PrivilegesAsClauses is used as role status output
 	// Update here so that state is reflected to the user prior to the next
 	// reconciler loop.
-	cr.Status.AtProvider.PrivilegesAsClauses = privs
+	mg.Status.AtProvider.PrivilegesAsClauses = privs
 
 	// Checks if current role configuration parameters differs from desired state.
 	// If difference, reset all parameters and apply desired parameters in a transaction
-	if cr.Spec.ForProvider.ConfigurationParameters != nil && !cmp.Equal(cr.Status.AtProvider.ConfigurationParameters, cr.Spec.ForProvider.ConfigurationParameters,
+	if mg.Spec.ForProvider.ConfigurationParameters != nil && !cmp.Equal(mg.Status.AtProvider.ConfigurationParameters, mg.Spec.ForProvider.ConfigurationParameters,
 		cmpopts.SortSlices(func(o, d namespacedv1alpha1.RoleConfigurationParameter) bool { return o.Name < d.Name })) {
 		q := make([]xsql.Query, 0)
 		q = append(q, xsql.Query{
 			String: fmt.Sprintf("ALTER ROLE %s RESET ALL", crn),
 		})
 		// search_path="$user", public is valid so need to handle that
-		for _, v := range *cr.Spec.ForProvider.ConfigurationParameters {
+		for _, v := range *mg.Spec.ForProvider.ConfigurationParameters {
 			sb := strings.Builder{}
 			values := strings.Split(v.Value, ",")
 			for i, v := range values {
@@ -403,9 +371,9 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 			return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateRole)
 		}
 		// Update state to reflect the current configuration parameters
-		cr.Status.AtProvider.ConfigurationParameters = cr.Spec.ForProvider.ConfigurationParameters
+		mg.Status.AtProvider.ConfigurationParameters = mg.Spec.ForProvider.ConfigurationParameters
 	}
-	cl := cr.Spec.ForProvider.ConnectionLimit
+	cl := mg.Spec.ForProvider.ConnectionLimit
 	if cl != nil {
 		if err := c.db.Exec(ctx, xsql.Query{
 			String: fmt.Sprintf("ALTER ROLE %s CONNECTION LIMIT %d", crn, int64(*cl)),
@@ -417,20 +385,16 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	// Only update connection details if password is changed
 	if pwchanged {
 		return managed.ExternalUpdate{
-			ConnectionDetails: c.db.GetConnectionDetails(meta.GetExternalName(cr), pw),
+			ConnectionDetails: c.db.GetConnectionDetails(meta.GetExternalName(mg), pw),
 		}, nil
 	}
 	return managed.ExternalUpdate{}, nil
 }
 
-func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
-	cr, ok := mg.(*namespacedv1alpha1.Role)
-	if !ok {
-		return managed.ExternalDelete{}, errors.New(errNotRole)
-	}
-	cr.SetConditions(xpv1.Deleting())
+func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Role) (managed.ExternalDelete, error) {
+	mg.SetConditions(xpv1.Deleting())
 	err := c.db.Exec(ctx, xsql.Query{
-		String: "DROP ROLE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(cr)),
+		String: "DROP ROLE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(mg)),
 	})
 	return managed.ExternalDelete{}, errors.Wrap(err, errDropRole)
 }


### PR DESCRIPTION
### Description of your changes

This commit refactors all controller reconcilers (cluster and namespaced,
across MSSQL, MySQL, and PostgreSQL) to improve type safety and eliminate
code duplication.

1. Removed redundant tracker wrapper pattern

  - Eliminated the tracker struct wrapper that only performed type assertions
  - Directly pass tracker.Track as a function to connectors

2. Improved type safety with specific generic types

  - Changed connectors from TypedExternalConnector[resource.Managed] to
    TypedExternalConnector[*v1alpha1.Resource] for each resource type
  - This provides compile-time type safety instead of runtime type assertions
  - Remove error constants like errNotDatabase, errNotGrant, errNotUser
  - Remove corresponding error handling code paths
  - Removed test cases for impossible "ErrNotResource" scenarios

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Covered by unit tests and e2e tests.

[contribution process]: https://git.io/fj2m9
