### PR TITLE
chore: Update to crossplane CLI for newer docker compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ GO111MODULE = on
 KIND_NODE_IMAGE_TAG ?= v1.32.8
 KIND_VERSION ?= v0.30.0
 KUBECTL_VERSION ?= v1.32.8
-CROSSPLANE_CLI_VERSION ?= v2.0.2
+CROSSPLANE_CLI_VERSION ?= v2.1.1
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
@@ -84,7 +84,7 @@ generate: crds.clean
 e2e.run: test-integration
 
 # Run integration tests.
-test-integration: $(KIND) $(KUBECTL) $(UP) $(HELM)
+test-integration: $(KIND) $(KUBECTL) $(CROSSPLANE_CLI) $(HELM)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
 	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed
@@ -107,9 +107,9 @@ go.mod.cachedir:
 	@go env GOMODCACHE
 
 # NOTE(hasheddan): we must ensure up is installed in tool cache prior to build
-# as including the k8s_tools machinery prior to the xpkg machinery sets UP to
+# as including the k8s_tools machinery prior to the xpkg machinery sets CROSSPLANE_CLI to
 # point to tool cache.
-build.init: $(UP)
+build.init: $(CROSSPLANE_CLI)
 
 # This is for running out-of-cluster locally, and is for convenience. Running
 # this make target will print out the command which was used. For more control,

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -86,7 +86,7 @@ setup_cluster() {
   local cache_path="${projectdir}/.work/inttest-package-cache"
   mkdir -p "${cache_path}/xpkg.crossplane.io"
   echo "created cache dir at ${cache_path}"
-  "${UP}" alpha xpkg xp-extract --from-xpkg "${OUTPUT_DIR}"/xpkg/linux_"${SAFEHOSTARCH}"/"${PACKAGE_NAME}"-"${VERSION}".xpkg -o "${cache_path}/xpkg.crossplane.io/${PACKAGE_NAME}:latest.gz"
+  "${CROSSPLANE_CLI}" xpkg extract --from-xpkg "${OUTPUT_DIR}"/xpkg/linux_"${SAFEHOSTARCH}"/"${PACKAGE_NAME}"-"${VERSION}".xpkg -o "${cache_path}/xpkg.crossplane.io/${PACKAGE_NAME}:latest.gz"
   chmod 644 "${cache_path}/xpkg.crossplane.io/${PACKAGE_NAME}:latest.gz"
 
   local node_image="kindest/node:${KIND_NODE_IMAGE_TAG}"


### PR DESCRIPTION
### Description of your changes

Switch to open Crossplane-cli, also updates to a version that works with newer docker. Otherwise we get this error:

> up: error: xpkg.buildCmd.Run(): Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`make build e2e`

[contribution process]: https://git.io/fj2m9
