### PR TITLE
Add safe-start capability

### DIFF
--- a/examples/activation-policy-no-cluster-mssql.yaml
+++ b/examples/activation-policy-no-cluster-mssql.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: disable-cluster-mssql
+spec:
+  activate:
+  # Activate all MySQL resources (both cluster and namespaced)
+  - "*.mysql.sql.crossplane.io"
+  - "*.mysql.sql.m.crossplane.io"
+  # Activate all PostgreSQL resources (both cluster and namespaced)
+  - "*.postgresql.sql.crossplane.io"
+  - "*.postgresql.sql.m.crossplane.io"
+  # Activate only namespaced MSSQL resources (cluster-wide MSSQL is excluded)
+  - "*.mssql.sql.m.crossplane.io"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.34.0
+	k8s.io/apiextensions-apiserver v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.0
@@ -100,7 +101,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.34.0 // indirect
 	k8s.io/client-go v0.34.0 // indirect
 	k8s.io/code-generator v0.34.0 // indirect
 	k8s.io/component-base v0.34.0 // indirect

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -30,3 +30,6 @@ metadata:
     friendly-kind-name.meta.crossplane.io/role.postgresql.sql.crossplane.io: Role
     friendly-kind-name.meta.crossplane.io/user.mysql.sql.crossplane.io: User
     friendly-kind-name.meta.crossplane.io/defaultprivileges.postgresql.sql.crossplane.io: DefaultPrivileges
+spec:
+  capabilities:
+  - safe-start

--- a/pkg/controller/cluster/mssql/config/config.go
+++ b/pkg/controller/cluster/mssql/config/config.go
@@ -46,3 +46,9 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 			providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
 			providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs.
+// ProviderConfig resources are always available, so this is equivalent to Setup.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	return Setup(mgr, o)
+}

--- a/pkg/controller/cluster/mssql/database/reconciler.go
+++ b/pkg/controller/cluster/mssql/database/reconciler.go
@@ -83,6 +83,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Database managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", clusterv1alpha1.DatabaseGroupVersionKind)
+		}
+	}, clusterv1alpha1.DatabaseGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube      client.Client
 	track     func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/mssql/grant/reconciler.go
+++ b/pkg/controller/cluster/mssql/grant/reconciler.go
@@ -84,6 +84,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Grant managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.GrantGroupVersionKind)
+		}
+	}, v1alpha1.GrantGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube      client.Client
 	track     func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/mssql/mssql.go
+++ b/pkg/controller/cluster/mssql/mssql.go
@@ -19,7 +19,7 @@ package mssql
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	xpcontroller "github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/mssql/config"
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/mssql/database"
@@ -29,12 +29,28 @@ import (
 
 // Setup creates all MSSQL controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
 		config.Setup,
 		database.Setup,
 		user.Setup,
 		grant.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupGated creates all MSSQL controllers with gated initialization,
+// waiting for their required CRDs to be available before starting.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
+		config.SetupGated,
+		database.SetupGated,
+		user.SetupGated,
+		grant.SetupGated,
 	} {
 		if err := setup(mgr, o); err != nil {
 			return err

--- a/pkg/controller/cluster/mssql/user/reconciler.go
+++ b/pkg/controller/cluster/mssql/user/reconciler.go
@@ -90,6 +90,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles User managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.UserGroupVersionKind)
+		}
+	}, v1alpha1.UserGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube      client.Client
 	track     func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/mysql/config/config.go
+++ b/pkg/controller/cluster/mysql/config/config.go
@@ -46,3 +46,9 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 			providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
 			providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs.
+// ProviderConfig resources are always available, so this is equivalent to Setup.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	return Setup(mgr, o)
+}

--- a/pkg/controller/cluster/mysql/database/reconciler.go
+++ b/pkg/controller/cluster/mysql/database/reconciler.go
@@ -83,6 +83,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Database managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.DatabaseGroupVersionKind)
+		}
+	}, v1alpha1.DatabaseGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/mysql/grant/reconciler.go
+++ b/pkg/controller/cluster/mysql/grant/reconciler.go
@@ -92,6 +92,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Grant managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.GrantGroupVersionKind)
+		}
+	}, v1alpha1.GrantGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/mysql/mysql.go
+++ b/pkg/controller/cluster/mysql/mysql.go
@@ -19,7 +19,7 @@ package mysql
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	xpcontroller "github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/mysql/config"
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/mysql/database"
@@ -29,12 +29,28 @@ import (
 
 // Setup creates all MySQL controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
 		config.Setup,
 		database.Setup,
 		user.Setup,
 		grant.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupGated creates all MySQL controllers with gated initialization,
+// waiting for their required CRDs to be available before starting.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
+		config.SetupGated,
+		database.SetupGated,
+		user.SetupGated,
+		grant.SetupGated,
 	} {
 		if err := setup(mgr, o); err != nil {
 			return err

--- a/pkg/controller/cluster/mysql/user/reconciler.go
+++ b/pkg/controller/cluster/mysql/user/reconciler.go
@@ -87,6 +87,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles User managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.UserGroupVersionKind)
+		}
+	}, v1alpha1.UserGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/postgresql/config/config.go
+++ b/pkg/controller/cluster/postgresql/config/config.go
@@ -46,3 +46,9 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 			providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
 			providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs.
+// ProviderConfig resources are always available, so this is equivalent to Setup.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	return Setup(mgr, o)
+}

--- a/pkg/controller/cluster/postgresql/database/reconciler.go
+++ b/pkg/controller/cluster/postgresql/database/reconciler.go
@@ -89,6 +89,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Database managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.DatabaseGroupVersionKind)
+		}
+	}, v1alpha1.DatabaseGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/postgresql/default_privileges/reconciler.go
+++ b/pkg/controller/cluster/postgresql/default_privileges/reconciler.go
@@ -59,7 +59,18 @@ const (
 	maxConcurrency = 5
 )
 
-// Setup adds a controller that reconciles Grant managed resources.
+// SetupGated adds a controller that reconciles DefaultPrivileges managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.DefaultPrivilegesGroupVersionKind)
+		}
+	}, v1alpha1.DefaultPrivilegesGroupVersionKind)
+	return nil
+}
+
+// Setup adds a controller that reconciles DefaultPrivileges managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.DefaultPrivilegesGroupKind)
 

--- a/pkg/controller/cluster/postgresql/extension/reconciler.go
+++ b/pkg/controller/cluster/postgresql/extension/reconciler.go
@@ -81,6 +81,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Extension managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.ExtensionGroupVersionKind)
+		}
+	}, v1alpha1.ExtensionGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/postgresql/grant/reconciler.go
+++ b/pkg/controller/cluster/postgresql/grant/reconciler.go
@@ -90,6 +90,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Grant managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.GrantGroupVersionKind)
+		}
+	}, v1alpha1.GrantGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/postgresql/postgresql.go
+++ b/pkg/controller/cluster/postgresql/postgresql.go
@@ -19,7 +19,7 @@ package postgresql
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	xpcontroller "github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/postgresql/config"
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/postgresql/database"
@@ -27,20 +27,39 @@ import (
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/postgresql/extension"
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/postgresql/grant"
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/postgresql/role"
-	"github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/postgresql/schema"
+	schemacontroller "github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/postgresql/schema"
 )
 
 // Setup creates all PostgreSQL controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
 		config.Setup,
 		database.Setup,
 		role.Setup,
 		grant.Setup,
 		extension.Setup,
-		schema.Setup,
+		schemacontroller.Setup,
 		default_privileges.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupGated creates all PostgreSQL controllers with gated initialization,
+// waiting for their required CRDs to be available before starting.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
+		config.SetupGated,
+		database.SetupGated,
+		role.SetupGated,
+		grant.SetupGated,
+		extension.SetupGated,
+		schemacontroller.SetupGated,
+		default_privileges.SetupGated,
 	} {
 		if err := setup(mgr, o); err != nil {
 			return err

--- a/pkg/controller/cluster/postgresql/role/reconciler.go
+++ b/pkg/controller/cluster/postgresql/role/reconciler.go
@@ -91,6 +91,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Role managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.RoleGroupVersionKind)
+		}
+	}, v1alpha1.RoleGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.LegacyManaged) error

--- a/pkg/controller/cluster/postgresql/schema/reconciler.go
+++ b/pkg/controller/cluster/postgresql/schema/reconciler.go
@@ -84,6 +84,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Schema managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.SchemaGroupVersionKind)
+		}
+	}, v1alpha1.SchemaGroupVersionKind)
+	return nil
+}
+
 var _ managed.TypedExternalConnector[*v1alpha1.Schema] = &connector{}
 
 type connector struct {

--- a/pkg/controller/namespaced/mssql/config/config.go
+++ b/pkg/controller/namespaced/mssql/config/config.go
@@ -46,3 +46,9 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 			providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
 			providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs.
+// ProviderConfig resources are always available, so this is equivalent to Setup.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	return Setup(mgr, o)
+}

--- a/pkg/controller/namespaced/mssql/database/reconciler.go
+++ b/pkg/controller/namespaced/mssql/database/reconciler.go
@@ -77,6 +77,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Database managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.DatabaseGroupVersionKind)
+		}
+	}, namespacedv1alpha1.DatabaseGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube      client.Client
 	track     func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/mssql/grant/reconciler.go
+++ b/pkg/controller/namespaced/mssql/grant/reconciler.go
@@ -80,6 +80,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Grant managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.GrantGroupVersionKind)
+		}
+	}, namespacedv1alpha1.GrantGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube      client.Client
 	track     func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/mssql/mssql.go
+++ b/pkg/controller/namespaced/mssql/mssql.go
@@ -19,7 +19,7 @@ package mssql
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	xpcontroller "github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/namespaced/mssql/config"
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/namespaced/mssql/database"
@@ -29,12 +29,28 @@ import (
 
 // Setup creates all MSSQL controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
 		config.Setup,
 		database.Setup,
 		user.Setup,
 		grant.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupGated creates all MSSQL controllers with gated initialization,
+// waiting for their required CRDs to be available before starting.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
+		config.SetupGated,
+		database.SetupGated,
+		user.SetupGated,
+		grant.SetupGated,
 	} {
 		if err := setup(mgr, o); err != nil {
 			return err

--- a/pkg/controller/namespaced/mssql/user/reconciler.go
+++ b/pkg/controller/namespaced/mssql/user/reconciler.go
@@ -86,6 +86,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles User managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.UserGroupVersionKind)
+		}
+	}, namespacedv1alpha1.UserGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube      client.Client
 	track     func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/mysql/config/config.go
+++ b/pkg/controller/namespaced/mysql/config/config.go
@@ -77,3 +77,9 @@ func setupClusterProviderConfig(mgr ctrl.Manager, o controller.Options) error {
 			providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
 			providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs.
+// ProviderConfig resources are always available, so this is equivalent to Setup.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	return Setup(mgr, o)
+}

--- a/pkg/controller/namespaced/mysql/database/reconciler.go
+++ b/pkg/controller/namespaced/mysql/database/reconciler.go
@@ -79,6 +79,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Database managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.DatabaseGroupVersionKind)
+		}
+	}, namespacedv1alpha1.DatabaseGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/mysql/grant/reconciler.go
+++ b/pkg/controller/namespaced/mysql/grant/reconciler.go
@@ -89,6 +89,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Grant managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.GrantGroupVersionKind)
+		}
+	}, namespacedv1alpha1.GrantGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/mysql/mysql.go
+++ b/pkg/controller/namespaced/mysql/mysql.go
@@ -19,7 +19,7 @@ package mysql
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	xpcontroller "github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/namespaced/mysql/config"
 	"github.com/crossplane-contrib/provider-sql/pkg/controller/namespaced/mysql/database"
@@ -29,12 +29,28 @@ import (
 
 // Setup creates all MySQL controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, o controller.Options) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
 		config.Setup,
 		database.Setup,
 		user.Setup,
 		grant.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupGated creates all MySQL controllers with gated initialization,
+// waiting for their required CRDs to be available before starting.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
+		config.SetupGated,
+		database.SetupGated,
+		user.SetupGated,
+		grant.SetupGated,
 	} {
 		if err := setup(mgr, o); err != nil {
 			return err

--- a/pkg/controller/namespaced/mysql/user/reconciler.go
+++ b/pkg/controller/namespaced/mysql/user/reconciler.go
@@ -84,6 +84,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles User managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.UserGroupVersionKind)
+		}
+	}, namespacedv1alpha1.UserGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/postgresql/config/config.go
+++ b/pkg/controller/namespaced/postgresql/config/config.go
@@ -46,3 +46,9 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 			providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
 			providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
+
+// SetupGated adds a controller that reconciles ProviderConfigs.
+// ProviderConfig resources are always available, so this is equivalent to Setup.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	return Setup(mgr, o)
+}

--- a/pkg/controller/namespaced/postgresql/database/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/database/reconciler.go
@@ -86,6 +86,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Database managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.DatabaseGroupVersionKind)
+		}
+	}, namespacedv1alpha1.DatabaseGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/postgresql/default_privileges/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/default_privileges/reconciler.go
@@ -59,7 +59,18 @@ const (
 	maxConcurrency = 5
 )
 
-// Setup adds a controller that reconciles Grant managed resources.
+// SetupGated adds a controller that reconciles DefaultPrivileges managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", v1alpha1.DefaultPrivilegesGroupVersionKind)
+		}
+	}, v1alpha1.DefaultPrivilegesGroupVersionKind)
+	return nil
+}
+
+// Setup adds a controller that reconciles DefaultPrivileges managed resources.
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.DefaultPrivilegesGroupKind)
 

--- a/pkg/controller/namespaced/postgresql/extension/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/extension/reconciler.go
@@ -78,6 +78,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Extension managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.ExtensionGroupVersionKind)
+		}
+	}, namespacedv1alpha1.ExtensionGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/postgresql/grant/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/grant/reconciler.go
@@ -87,6 +87,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Grant managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.GrantGroupVersionKind)
+		}
+	}, namespacedv1alpha1.GrantGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/postgresql/role/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/role/reconciler.go
@@ -88,6 +88,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Role managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.RoleGroupVersionKind)
+		}
+	}, namespacedv1alpha1.RoleGroupVersionKind)
+	return nil
+}
+
 type connector struct {
 	kube  client.Client
 	track func(ctx context.Context, mg resource.ModernManaged) error

--- a/pkg/controller/namespaced/postgresql/schema/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/schema/reconciler.go
@@ -81,6 +81,17 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		Complete(r)
 }
 
+// SetupGated adds a controller that reconciles Schema managed resources
+// with gated initialization, waiting for the resource's CRD to be available.
+func SetupGated(mgr ctrl.Manager, o xpcontroller.Options) error {
+	o.Gate.Register(func() {
+		if err := Setup(mgr, o); err != nil {
+			mgr.GetLogger().Error(err, "unable to setup controller", "gvk", namespacedv1alpha1.SchemaGroupVersionKind)
+		}
+	}, namespacedv1alpha1.SchemaGroupVersionKind)
+	return nil
+}
+
 var _ managed.TypedExternalConnector[*namespacedv1alpha1.Schema] = &connector{}
 
 type connector struct {

--- a/pkg/controller/sql.go
+++ b/pkg/controller/sql.go
@@ -19,7 +19,7 @@ package controller
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	xpcontroller "github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 
 	clustermssql "github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/mssql"
 	clustermysql "github.com/crossplane-contrib/provider-sql/pkg/controller/cluster/mysql"
@@ -31,14 +31,32 @@ import (
 
 // Setup creates all controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, l controller.Options) error {
-	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+func Setup(mgr ctrl.Manager, l xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
 		clustermssql.Setup,
 		clustermysql.Setup,
 		clusterpostgresql.Setup,
 		namespacedmssql.Setup,
 		namespacedmysql.Setup,
 		namespacedpostgresql.Setup,
+	} {
+		if err := setup(mgr, l); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetupGated creates all controllers with gated initialization, waiting for
+// their required CRDs to be available before starting.
+func SetupGated(mgr ctrl.Manager, l xpcontroller.Options) error {
+	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
+		clustermssql.SetupGated,
+		clustermysql.SetupGated,
+		clusterpostgresql.SetupGated,
+		namespacedmssql.SetupGated,
+		namespacedmysql.SetupGated,
+		namespacedpostgresql.SetupGated,
 	} {
 		if err := setup(mgr, l); err != nil {
 			return err


### PR DESCRIPTION
### Description of your changes

This allows cluster operators to disable namespaced or clusterwide
resources, and disable database types that they do not require.

* Providers create ManagedResourceDefinitions but CRDs only when activated
* Users activate only needed resources through ManagedResourceActivationPolicies
* Significant reduction in cluster resource overhead

https://docs.crossplane.io/latest/guides/implementing-safe-start/

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
