### PR TITLE
fix: MySQL namespaced providerconfig used wrong type - CannotConnectToProvider

### DIFF
--- a/apis/namespaced/mysql/v1alpha1/provider_types.go
+++ b/apis/namespaced/mysql/v1alpha1/provider_types.go
@@ -98,11 +98,11 @@ type ProviderConfig struct {
 
 // +kubebuilder:object:root=true
 
-// A ProviderConfigList contains a list of ClusterProviderConfig.
+// A ProviderConfigList contains a list of ProviderConfig.
 type ProviderConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ClusterProviderConfig `json:"items"`
+	Items           []ProviderConfig `json:"items"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/namespaced/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -468,7 +468,7 @@ func (in *ProviderConfigList) DeepCopyInto(out *ProviderConfigList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]ClusterProviderConfig, len(*in))
+		*out = make([]ProviderConfig, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
### Description of your changes

I got this error in e2e tests when adding safe start:

    Warning  CannotConnectToProvider  62s (x15 over 2m24s)    managed/grant.mysql.sql.m.crossplane.io  cannot get ProviderConfig: cache had type *v1alpha1.ClusterProviderConfig, but *v1alpha1.ProviderConfig was asked for

The Items type here was wrong in the Crossplane v2 update: ProviderConfigList  Items []ClusterProviderConfig

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

e2e tests on my safe start branch works OK

[contribution process]: https://git.io/fj2m9
