### PR TITLE
fix: Namespaced PostgreSQL extension did not use namespaced database reference

### DIFF
--- a/apis/namespaced/postgresql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/postgresql/v1alpha1/zz_generated.deepcopy.go
@@ -356,12 +356,12 @@ func (in *ExtensionParameters) DeepCopyInto(out *ExtensionParameters) {
 	}
 	if in.DatabaseRef != nil {
 		in, out := &in.DatabaseRef, &out.DatabaseRef
-		*out = new(v1.Reference)
+		*out = new(v1.NamespacedReference)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.DatabaseSelector != nil {
 		in, out := &in.DatabaseSelector, &out.DatabaseSelector
-		*out = new(v1.Selector)
+		*out = new(v1.NamespacedSelector)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/examples/namespaced/postgresql/extension.yaml
+++ b/examples/namespaced/postgresql/extension.yaml
@@ -9,6 +9,7 @@ spec:
     version: "1.4"
     databaseRef:
       name: example
+      # namespace: default  # Optional - defaults to the same namespace as the Extension
   providerConfigRef:
     kind: ProviderConfig
     name: default
@@ -24,6 +25,7 @@ spec:
     version: "1.1"
     databaseRef:
       name: example
+      namespace: default  # Explicitly set namespace (demonstrates namespace scoping)
   providerConfigRef:
     kind: ProviderConfig
     name: default

--- a/package/crds/postgresql.sql.m.crossplane.io_extensions.yaml
+++ b/package/crds/postgresql.sql.m.crossplane.io_extensions.yaml
@@ -77,6 +77,9 @@ spec:
                       name:
                         description: Name of the referenced object.
                         type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
                       policy:
                         description: Policies for referencing.
                         properties:
@@ -120,6 +123,9 @@ spec:
                         description: MatchLabels ensures an object with matching labels
                           is selected.
                         type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
                       policy:
                         description: Policies for selection.
                         properties:


### PR DESCRIPTION
### Description of your changes

Change namespaced PostgreSQL extension to use namespaced database references.

Add e2e tests to cover this, without the fix, it fails with this
error:

    Warning  CannotResolveResourceReferences  36s (x14 over 77s)  managed/extension.postgresql.sql.m.crossplane.io  cannot resolve references: spec.forProvider.database: cannot get referenced resource: Database.postgresql.sql.m.crossplane.io "example" not found

Fixes #285

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

e2e tests

[contribution process]: https://git.io/fj2m9
