### PR TITLE
chore: update base image hash and add tag and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
     - dependency-name: "github.com/crossplane/crossplane-tools"
     - dependency-name: "sigs.k8s.io/*"
     - dependency-name: "k8s.io/*"
+- package-ecosystem: docker
+  directory: "/cluster/images/provider-sql"
+  schedule:
+    interval: monthly
+  commit-message:
+    prefix: "chore: "
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/cluster/images/provider-sql/Dockerfile
+++ b/cluster/images/provider-sql/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static@sha256:1f580b0a1922c3e54ae15b0758b5747b260bd99d39d40c2edb3e7f6e2452298b
+FROM gcr.io/distroless/static:nonroot@sha256:01e550fdb7ab79ee7be5ff440a563a58f1fd000ad9e0c532e65c3d23f917f1c5
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION

### Description of your changes

Dependabot should be able to make PRs by adding the tag (nonroot) to
this image. The tzdata file in the current release is outdated.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

make build e2e

[contribution process]: https://git.io/fj2m9
