### PR TITLE
chore: use OIDC for codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -174,6 +177,7 @@ jobs:
       - name: Publish Unit Test Coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
+          use_oidc: true
           flags: unittests
           files: _output/tests/linux_amd64/coverage.txt
 


### PR DESCRIPTION
### Description of your changes

codecov has been broken for a while, try using OIDC to get it working
again.

Reference:
https://github.com/codecov/codecov-action?tab=readme-ov-file#using-oidc

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A, testing will be done in the codecov pipeline.

[contribution process]: https://git.io/fj2m9
