### PR TITLE
feat(mysql): Allow to Grant permissions on specific columns in table

### DIFF
--- a/apis/cluster/mysql/v1alpha1/grant_types.go
+++ b/apis/cluster/mysql/v1alpha1/grant_types.go
@@ -29,7 +29,7 @@ type GrantSpec struct {
 }
 
 // GrantPrivilege represents a privilege to be granted
-// +kubebuilder:validation:Pattern:=^[A-Z_ ]+$
+// +kubebuilder:validation:Pattern:="^[A-Za-z0-9_,() ]+$"
 type GrantPrivilege string
 
 // If Privileges are specified, we should have at least one

--- a/apis/cluster/mysql/v1alpha1/grant_types.go
+++ b/apis/cluster/mysql/v1alpha1/grant_types.go
@@ -29,7 +29,7 @@ type GrantSpec struct {
 }
 
 // GrantPrivilege represents a privilege to be granted
-// +kubebuilder:validation:Pattern:="^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$"
+// +kubebuilder:validation:Pattern:="^([A-Z0-9_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$"
 type GrantPrivilege string
 
 // If Privileges are specified, we should have at least one

--- a/apis/cluster/mysql/v1alpha1/grant_types.go
+++ b/apis/cluster/mysql/v1alpha1/grant_types.go
@@ -29,7 +29,7 @@ type GrantSpec struct {
 }
 
 // GrantPrivilege represents a privilege to be granted
-// +kubebuilder:validation:Pattern:="^[A-Za-z0-9_,() ]+$"
+// +kubebuilder:validation:Pattern:="^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$"
 type GrantPrivilege string
 
 // If Privileges are specified, we should have at least one

--- a/apis/namespaced/mysql/v1alpha1/grant_types.go
+++ b/apis/namespaced/mysql/v1alpha1/grant_types.go
@@ -31,7 +31,7 @@ type GrantSpec struct {
 }
 
 // GrantPrivilege represents a privilege to be granted
-// +kubebuilder:validation:Pattern:=^[A-Z_ ]+$
+// +kubebuilder:validation:Pattern:="^[A-Za-z0-9_,() ]+$"
 type GrantPrivilege string
 
 // If Privileges are specified, we should have at least one

--- a/apis/namespaced/mysql/v1alpha1/grant_types.go
+++ b/apis/namespaced/mysql/v1alpha1/grant_types.go
@@ -31,7 +31,7 @@ type GrantSpec struct {
 }
 
 // GrantPrivilege represents a privilege to be granted
-// +kubebuilder:validation:Pattern:="^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$"
+// +kubebuilder:validation:Pattern:="^([A-Z0-9_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$"
 type GrantPrivilege string
 
 // If Privileges are specified, we should have at least one

--- a/apis/namespaced/mysql/v1alpha1/grant_types.go
+++ b/apis/namespaced/mysql/v1alpha1/grant_types.go
@@ -31,7 +31,7 @@ type GrantSpec struct {
 }
 
 // GrantPrivilege represents a privilege to be granted
-// +kubebuilder:validation:Pattern:="^[A-Za-z0-9_,() ]+$"
+// +kubebuilder:validation:Pattern:="^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$"
 type GrantPrivilege string
 
 // If Privileges are specified, we should have at least one

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -373,10 +373,15 @@ test_update_user_password() {
 
 test_create_grant() {
   echo_step "test creating MySQL Grant resource"
+  "${KUBECTL}" exec mariadb-0 -- bash -c \
+  'mariadb -uroot -p${MARIADB_ROOT_PASSWORD} -N -e "CREATE TABLE \`example-db\`.\`example-table\` (id INT, status VARCHAR(50), updated_at TIMESTAMP);"'
+
   "${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/mysql/grant_database.yaml
+  "${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/mysql/grant_table.yaml
 
   echo_info "check if is ready"
   "${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/mysql/grant_database.yaml
+  "${KUBECTL}" wait --timeout 2m --for condition=Ready -f ${projectdir}/examples/${API_TYPE}/mysql/grant_table.yaml
   echo_step_completed
 }
 
@@ -393,6 +398,7 @@ test_all() {
 cleanup_test_resources() {
   echo_step "cleaning up test resources"
   "${KUBECTL}" delete -f ${projectdir}/examples/${API_TYPE}/mysql/grant_database.yaml
+  "${KUBECTL}" delete -f ${projectdir}/examples/${API_TYPE}/mysql/grant_table.yaml
   "${KUBECTL}" delete -f ${projectdir}/examples/${API_TYPE}/mysql/database.yaml
   "${KUBECTL}" delete -f ${projectdir}/examples/${API_TYPE}/mysql/user.yaml
   "${KUBECTL}" delete secret example-pw

--- a/examples/cluster/mysql/grant_table.yaml
+++ b/examples/cluster/mysql/grant_table.yaml
@@ -8,6 +8,7 @@ spec:
       - DROP
       - INSERT
       - SELECT
+      - UPDATE (status, updated_at)
     table: example-table
     userRef:
       name: example-user

--- a/examples/cluster/mysql/grant_table.yaml
+++ b/examples/cluster/mysql/grant_table.yaml
@@ -8,7 +8,7 @@ spec:
       - DROP
       - INSERT
       - SELECT
-      - UPDATE (status, updated_at)
+      - UPDATE (`status`, `updated_at`)
     table: example-table
     userRef:
       name: example-user

--- a/examples/namespaced/mysql/grant_table.yaml
+++ b/examples/namespaced/mysql/grant_table.yaml
@@ -9,8 +9,12 @@ spec:
       - DROP
       - INSERT
       - SELECT
+      - UPDATE (status, updated_at)
     table: example-table
     userRef:
       name: example-user
     databaseRef:
       name: example-db
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/examples/namespaced/mysql/grant_table.yaml
+++ b/examples/namespaced/mysql/grant_table.yaml
@@ -9,7 +9,7 @@ spec:
       - DROP
       - INSERT
       - SELECT
-      - UPDATE (status, updated_at)
+      - UPDATE (`status`, `updated_at`)
     table: example-table
     userRef:
       name: example-user

--- a/package/crds/mysql.sql.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.crossplane.io_grants.yaml
@@ -170,7 +170,7 @@ spec:
                       See https://mariadb.com/kb/en/grant/#database-privileges for available privileges.
                     items:
                       description: GrantPrivilege represents a privilege to be granted
-                      pattern: ^[A-Z_ ]+$
+                      pattern: ^[A-Za-z0-9_,() ]+$
                       type: string
                     minItems: 1
                     type: array

--- a/package/crds/mysql.sql.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.crossplane.io_grants.yaml
@@ -170,7 +170,7 @@ spec:
                       See https://mariadb.com/kb/en/grant/#database-privileges for available privileges.
                     items:
                       description: GrantPrivilege represents a privilege to be granted
-                      pattern: ^[A-Za-z0-9_,() ]+$
+                      pattern: ^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$
                       type: string
                     minItems: 1
                     type: array

--- a/package/crds/mysql.sql.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.crossplane.io_grants.yaml
@@ -170,7 +170,7 @@ spec:
                       See https://mariadb.com/kb/en/grant/#database-privileges for available privileges.
                     items:
                       description: GrantPrivilege represents a privilege to be granted
-                      pattern: ^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$
+                      pattern: ^([A-Z0-9_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$
                       type: string
                     minItems: 1
                     type: array

--- a/package/crds/mysql.sql.m.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.m.crossplane.io_grants.yaml
@@ -162,7 +162,7 @@ spec:
                       See https://mariadb.com/kb/en/grant/#database-privileges for available privileges.
                     items:
                       description: GrantPrivilege represents a privilege to be granted
-                      pattern: ^[A-Z_ ]+$
+                      pattern: ^[A-Za-z0-9_,() ]+$
                       type: string
                     minItems: 1
                     type: array

--- a/package/crds/mysql.sql.m.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.m.crossplane.io_grants.yaml
@@ -162,7 +162,7 @@ spec:
                       See https://mariadb.com/kb/en/grant/#database-privileges for available privileges.
                     items:
                       description: GrantPrivilege represents a privilege to be granted
-                      pattern: ^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$
+                      pattern: ^([A-Z0-9_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$
                       type: string
                     minItems: 1
                     type: array

--- a/package/crds/mysql.sql.m.crossplane.io_grants.yaml
+++ b/package/crds/mysql.sql.m.crossplane.io_grants.yaml
@@ -162,7 +162,7 @@ spec:
                       See https://mariadb.com/kb/en/grant/#database-privileges for available privileges.
                     items:
                       description: GrantPrivilege represents a privilege to be granted
-                      pattern: ^[A-Za-z0-9_,() ]+$
+                      pattern: ^([A-Z_ ]+|[A-Z_ ]+ [(]`[^`]+`(, `[^`]+`)*[)])$
                       type: string
                     minItems: 1
                     type: array

--- a/pkg/controller/cluster/mysql/grant/reconciler.go
+++ b/pkg/controller/cluster/mysql/grant/reconciler.go
@@ -179,10 +179,41 @@ func defaultIdentifier(identifier *string) string {
 	return "*"
 }
 
+func splitGrantPrivileges(s string) []string {
+	var out []string
+	start := 0
+	depth := 0
+
+	emit := func(end int) {
+		perm := strings.TrimSpace(s[start:end])
+		if perm != "" {
+			out = append(out, perm)
+		}
+	}
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				emit(i)
+				start = i + 1
+			}
+		}
+	}
+	emit(len(s))
+	return out
+}
+
 func parseGrant(grant, dbname string, table string) (privileges []string) {
 	matches := grantRegex.FindStringSubmatch(grant)
 	if len(matches) == 5 && matches[2] == dbname && matches[3] == table {
-		privileges := strings.Split(matches[1], ", ")
+		privileges := splitGrantPrivileges(matches[1])
 
 		if matches[4] != "" {
 			privileges = append(privileges, "GRANT OPTION")
@@ -376,13 +407,31 @@ func (c *external) Delete(ctx context.Context, mg *v1alpha1.Grant) (managed.Exte
 	return managed.ExternalDelete{}, nil
 }
 
+func normalizePrivilege(p string) string {
+	p = strings.TrimSpace(p)
+
+	start := strings.Index(p, "(")
+	end := strings.LastIndex(p, ")")
+
+	if start == -1 || end == -1 || end <= start {
+		return p
+	}
+
+	cols := p[start+1 : end]
+
+	parts := splitGrantPrivileges(cols)
+	sort.Strings(parts)
+
+	return p[:start+1] + strings.Join(parts, ", ") + p[end:]
+}
+
 func diffPermissions(desired, observed []string) ([]string, []string) {
 	desiredMap := make(map[string]struct{}, len(desired))
 	observedMap := make(map[string]struct{}, len(observed))
 
 	for _, desiredPrivilege := range desired {
 		// Special case because ALL is an alias for "ALL PRIVILEGES"
-		desiredPrivilegeMapped := strings.ReplaceAll(desiredPrivilege, allPrivileges, "ALL")
+		desiredPrivilegeMapped := strings.ReplaceAll(normalizePrivilege(desiredPrivilege), allPrivileges, "ALL")
 		desiredMap[desiredPrivilegeMapped] = struct{}{}
 	}
 	for _, observedPrivilege := range observed {

--- a/pkg/controller/namespaced/mysql/grant/reconciler.go
+++ b/pkg/controller/namespaced/mysql/grant/reconciler.go
@@ -162,10 +162,41 @@ func defaultIdentifier(identifier *string) string {
 	return "*"
 }
 
+func splitGrantPrivileges(s string) []string {
+	var out []string
+	start := 0
+	depth := 0
+
+	emit := func(end int) {
+		perm := strings.TrimSpace(s[start:end])
+		if perm != "" {
+			out = append(out, perm)
+		}
+	}
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				emit(i)
+				start = i + 1
+			}
+		}
+	}
+	emit(len(s))
+	return out
+}
+
 func parseGrant(grant, dbname string, table string) (privileges []string) {
 	matches := grantRegex.FindStringSubmatch(grant)
 	if len(matches) == 5 && matches[2] == dbname && matches[3] == table {
-		privileges := strings.Split(matches[1], ", ")
+		privileges := splitGrantPrivileges(matches[1])
 
 		if matches[4] != "" {
 			privileges = append(privileges, "GRANT OPTION")
@@ -359,13 +390,31 @@ func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Grant) (ma
 	return managed.ExternalDelete{}, nil
 }
 
+func normalizePrivilege(p string) string {
+	p = strings.TrimSpace(p)
+
+	start := strings.Index(p, "(")
+	end := strings.LastIndex(p, ")")
+
+	if start == -1 || end == -1 || end <= start {
+		return p
+	}
+
+	cols := p[start+1 : end]
+
+	parts := splitGrantPrivileges(cols)
+	sort.Strings(parts)
+
+	return p[:start+1] + strings.Join(parts, ", ") + p[end:]
+}
+
 func diffPermissions(desired, observed []string) ([]string, []string) {
 	desiredMap := make(map[string]struct{}, len(desired))
 	observedMap := make(map[string]struct{}, len(observed))
 
 	for _, desiredPrivilege := range desired {
 		// Special case because ALL is an alias for "ALL PRIVILEGES"
-		desiredPrivilegeMapped := strings.ReplaceAll(desiredPrivilege, allPrivileges, "ALL")
+		desiredPrivilegeMapped := strings.ReplaceAll(normalizePrivilege(desiredPrivilege), allPrivileges, "ALL")
 		desiredMap[desiredPrivilegeMapped] = struct{}{}
 	}
 	for _, observedPrivilege := range observed {


### PR DESCRIPTION
### Description of your changes
Improved regexp expression for granting permission to specific columns in MySQL.

Fixes #214, #176

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
```
apiVersion: mysql.sql.crossplane.io/v1alpha1
kind: Grant
metadata:
  name: user-example
spec:
  forProvider:
    databaseRef:
      name: example-db
    privileges:
      - UPDATE (`status`, `updated_at`)
      - SELECT
    table: requests
    user: user-example@%
  providerConfigRef:
    name: example
```