### PR TITLE
chore: add fernandezcuesta to OWNERS

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -13,6 +13,7 @@ Please see [GOVERNANCE.md] for governance guidelines and responsibilities.
 * Javier Palomo ([jvrplmlmn](https://github.com/jvrplmlmn))
 * Iain Lane ([iainlane](https://github.com/iainlane))
 * Carl Henrik Lunde ([chlunde](https://github.com/chlunde))
+* J. Fernández ([fernandezcuesta](https://github.com/fernandezcuesta))
 
 ## Emeritus maintainers
 


### PR DESCRIPTION
I propose adding J. Fernández to the maintainer team. He's active on provider-sql on slack, and across and has been involved in multiple PRs/issues like #235, #312, #310, #236, #216 and #215.

He has show consistent activity from 2023 through Feb 2026.

This will ensure we redundancy in the maintainer team.