### PR TITLE
feat(postgres): Add support for setting STRATEGY during db creation

### DIFF
--- a/apis/cluster/postgresql/v1alpha1/database_types.go
+++ b/apis/cluster/postgresql/v1alpha1/database_types.go
@@ -22,7 +22,18 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 )
 
+// DatabaseStrategy sets the method that is used to create a database.
+type DatabaseStrategy string
+
+const (
+	// DatabaseStrategyWALLog copies blocks through the write-ahead log.
+	DatabaseStrategyWALLog DatabaseStrategy = "WAL_LOG"
+	// DatabaseStrategyFileCopy copies the template database files directly.
+	DatabaseStrategyFileCopy DatabaseStrategy = "FILE_COPY"
+)
+
 // DatabaseParameters are the configurable fields of a Database.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf) || self.strategy == oldSelf.strategy",message="strategy field is immutable after creation",optionalOldSelf=true
 type DatabaseParameters struct {
 	// The role name of the user who will own the new database, or DEFAULT to
 	// use the default (namely, the user executing the command). To create a
@@ -33,6 +44,13 @@ type DatabaseParameters struct {
 	// The name of the template from which to create the new database, or
 	// DEFAULT to use the default template (template1).
 	Template *string `json:"template,omitempty"`
+
+	// Strategy sets the method used to create the database from the template.
+	// This field is create-only and requires PostgreSQL 15+.
+	// When omitted, PostgreSQL uses the server default.
+	// +kubebuilder:validation:Enum=WAL_LOG;FILE_COPY
+	// +optional
+	Strategy *DatabaseStrategy `json:"strategy,omitempty"`
 
 	// Character set encoding to use in the new database. Specify a string
 	// constant (e.g., 'SQL_ASCII'), or an integer encoding number, or DEFAULT

--- a/apis/cluster/postgresql/v1alpha1/database_types.go
+++ b/apis/cluster/postgresql/v1alpha1/database_types.go
@@ -33,7 +33,7 @@ const (
 )
 
 // DatabaseParameters are the configurable fields of a Database.
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf) || self.strategy == oldSelf.strategy",message="strategy field is immutable after creation",optionalOldSelf=true
+// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy)) || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy == oldSelf.value().strategy))",message="strategy field is immutable after creation",optionalOldSelf=true
 type DatabaseParameters struct {
 	// The role name of the user who will own the new database, or DEFAULT to
 	// use the default (namely, the user executing the command). To create a

--- a/apis/cluster/postgresql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/postgresql/v1alpha1/zz_generated.deepcopy.go
@@ -85,6 +85,11 @@ func (in *DatabaseParameters) DeepCopyInto(out *DatabaseParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(DatabaseStrategy)
+		**out = **in
+	}
 	if in.Encoding != nil {
 		in, out := &in.Encoding, &out.Encoding
 		*out = new(string)

--- a/apis/namespaced/postgresql/v1alpha1/database_types.go
+++ b/apis/namespaced/postgresql/v1alpha1/database_types.go
@@ -34,7 +34,7 @@ const (
 )
 
 // DatabaseParameters are the configurable fields of a Database.
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf) || self.strategy == oldSelf.strategy",message="strategy field is immutable after creation",optionalOldSelf=true
+// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy)) || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy == oldSelf.value().strategy))",message="strategy field is immutable after creation",optionalOldSelf=true
 type DatabaseParameters struct {
 	// The role name of the user who will own the new database, or DEFAULT to
 	// use the default (namely, the user executing the command). To create a

--- a/apis/namespaced/postgresql/v1alpha1/database_types.go
+++ b/apis/namespaced/postgresql/v1alpha1/database_types.go
@@ -23,7 +23,18 @@ import (
 	xpv2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
 )
 
+// DatabaseStrategy sets the method that is used to create a database.
+type DatabaseStrategy string
+
+const (
+	// DatabaseStrategyWALLog copies blocks through the write-ahead log.
+	DatabaseStrategyWALLog DatabaseStrategy = "WAL_LOG"
+	// DatabaseStrategyFileCopy copies the template database files directly.
+	DatabaseStrategyFileCopy DatabaseStrategy = "FILE_COPY"
+)
+
 // DatabaseParameters are the configurable fields of a Database.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf) || self.strategy == oldSelf.strategy",message="strategy field is immutable after creation",optionalOldSelf=true
 type DatabaseParameters struct {
 	// The role name of the user who will own the new database, or DEFAULT to
 	// use the default (namely, the user executing the command). To create a
@@ -34,6 +45,13 @@ type DatabaseParameters struct {
 	// The name of the template from which to create the new database, or
 	// DEFAULT to use the default template (template1).
 	Template *string `json:"template,omitempty"`
+
+	// Strategy sets the method used to create the database from the template.
+	// This field is create-only and requires PostgreSQL 15+.
+	// When omitted, PostgreSQL uses the server default.
+	// +kubebuilder:validation:Enum=WAL_LOG;FILE_COPY
+	// +optional
+	Strategy *DatabaseStrategy `json:"strategy,omitempty"`
 
 	// Character set encoding to use in the new database. Specify a string
 	// constant (e.g., 'SQL_ASCII'), or an integer encoding number, or DEFAULT

--- a/apis/namespaced/postgresql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/postgresql/v1alpha1/zz_generated.deepcopy.go
@@ -197,6 +197,11 @@ func (in *DatabaseParameters) DeepCopyInto(out *DatabaseParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(DatabaseStrategy)
+		**out = **in
+	}
 	if in.Encoding != nil {
 		in, out := &in.Encoding, &out.Encoding
 		*out = new(string)

--- a/examples/cluster/postgresql/database-strategy.yaml
+++ b/examples/cluster/postgresql/database-strategy.yaml
@@ -1,0 +1,9 @@
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: strategy-db
+spec:
+  forProvider:
+    template: strategy-template
+    # Optional, create-only, and supported on PostgreSQL 15+.
+    strategy: FILE_COPY

--- a/examples/namespaced/postgresql/database-strategy.yaml
+++ b/examples/namespaced/postgresql/database-strategy.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: strategy-db
+  namespace: default
+spec:
+  forProvider:
+    template: strategy-template
+    # Optional, create-only, and supported on PostgreSQL 15+.
+    strategy: FILE_COPY
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/package/crds/postgresql.sql.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_databases.yaml
@@ -117,6 +117,15 @@ spec:
                       database owned by another role, you must be a direct or indirect member
                       of that role, or be a superuser.
                     type: string
+                  strategy:
+                    description: |-
+                      Strategy sets the method used to create the database from the template.
+                      This field is create-only and requires PostgreSQL 15+.
+                      When omitted, PostgreSQL uses the server default.
+                    enum:
+                    - WAL_LOG
+                    - FILE_COPY
+                    type: string
                   tablespace:
                     description: |-
                       The name of the tablespace that will be associated with the new database,
@@ -130,6 +139,10 @@ spec:
                       DEFAULT to use the default template (template1).
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: strategy field is immutable after creation
+                  optionalOldSelf: true
+                  rule: '!has(oldSelf) || self.strategy == oldSelf.strategy'
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/postgresql.sql.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_databases.yaml
@@ -142,7 +142,9 @@ spec:
                 x-kubernetes-validations:
                 - message: strategy field is immutable after creation
                   optionalOldSelf: true
-                  rule: '!has(oldSelf) || self.strategy == oldSelf.strategy'
+                  rule: '!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy))
+                    || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy
+                    == oldSelf.value().strategy))'
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
@@ -128,7 +128,9 @@ spec:
                 x-kubernetes-validations:
                 - message: strategy field is immutable after creation
                   optionalOldSelf: true
-                  rule: '!has(oldSelf) || self.strategy == oldSelf.strategy'
+                  rule: '!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy))
+                    || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy
+                    == oldSelf.value().strategy))'
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
@@ -103,6 +103,15 @@ spec:
                       database owned by another role, you must be a direct or indirect member
                       of that role, or be a superuser.
                     type: string
+                  strategy:
+                    description: |-
+                      Strategy sets the method used to create the database from the template.
+                      This field is create-only and requires PostgreSQL 15+.
+                      When omitted, PostgreSQL uses the server default.
+                    enum:
+                    - WAL_LOG
+                    - FILE_COPY
+                    type: string
                   tablespace:
                     description: |-
                       The name of the tablespace that will be associated with the new database,
@@ -116,6 +125,10 @@ spec:
                       DEFAULT to use the default template (template1).
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: strategy field is immutable after creation
+                  optionalOldSelf: true
+                  rule: '!has(oldSelf) || self.strategy == oldSelf.strategy'
               managementPolicies:
                 default:
                 - '*'

--- a/pkg/controller/cluster/postgresql/database/reconciler.go
+++ b/pkg/controller/cluster/postgresql/database/reconciler.go
@@ -53,6 +53,7 @@ const (
 	errGetSecret    = "cannot get credentials Secret"
 
 	errSelectDB          = "cannot select database"
+	errSelectServerVer   = "cannot determine PostgreSQL server version"
 	errCreateDB          = "cannot create database"
 	errAlterDBOwner      = "cannot alter database owner"
 	errAlterDBConnLimit  = "cannot alter database connection limit"
@@ -60,7 +61,8 @@ const (
 	errAlterDBIsTmpl     = "cannot alter database is template"
 	errDropDB            = "cannot drop database"
 
-	maxConcurrency = 5
+	maxConcurrency                   = 5
+	minDatabaseStrategyServerVersion = 150000
 )
 
 // Setup adds a controller that reconciles Database managed resources.
@@ -194,6 +196,11 @@ func (c *external) Observe(ctx context.Context, mg *v1alpha1.Database) (managed.
 func (c *external) Create(ctx context.Context, mg *v1alpha1.Database) (managed.ExternalCreation, error) { //nolint:gocyclo
 	// NOTE(negz): This is only a tiny bit over our cyclomatic complexity limit,
 	// and more readable than if we refactored it to avoid the linter error.
+	if mg.Spec.ForProvider.Strategy != nil {
+		if err := c.ensureDatabaseStrategySupport(ctx); err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, errCreateDB)
+		}
+	}
 
 	var b strings.Builder
 	b.WriteString("CREATE DATABASE ")
@@ -206,6 +213,10 @@ func (c *external) Create(ctx context.Context, mg *v1alpha1.Database) (managed.E
 	if mg.Spec.ForProvider.Template != nil {
 		b.WriteString(" TEMPLATE ")
 		b.WriteString(quoteIfIdentifier(*mg.Spec.ForProvider.Template))
+	}
+	if mg.Spec.ForProvider.Strategy != nil {
+		b.WriteString(" STRATEGY ")
+		b.WriteString(string(*mg.Spec.ForProvider.Strategy))
 	}
 	if mg.Spec.ForProvider.Encoding != nil {
 		b.WriteString(" ENCODING ")
@@ -234,6 +245,18 @@ func (c *external) Create(ctx context.Context, mg *v1alpha1.Database) (managed.E
 	}
 
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: b.String()}), errCreateDB)
+}
+
+func (c *external) ensureDatabaseStrategySupport(ctx context.Context) error {
+	var serverVersion int
+	err := c.db.Scan(ctx, xsql.Query{String: "SELECT current_setting('server_version_num')::integer"}, &serverVersion)
+	if err != nil {
+		return errors.Wrap(err, errSelectServerVer)
+	}
+	if serverVersion < minDatabaseStrategyServerVersion {
+		return errors.Errorf("database strategy requires PostgreSQL 15+; found server_version_num=%d", serverVersion)
+	}
+	return nil
 }
 
 func (c *external) Update(ctx context.Context, mg *v1alpha1.Database) (managed.ExternalUpdate, error) { //nolint:gocyclo
@@ -289,8 +312,8 @@ func (c *external) Delete(ctx context.Context, mg *v1alpha1.Database) (managed.E
 }
 
 func upToDate(observed, desired v1alpha1.DatabaseParameters) bool {
-	// Template is only used at create time.
-	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(v1alpha1.DatabaseParameters{}, "Template"))
+	// Template and strategy are only used at create time.
+	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(v1alpha1.DatabaseParameters{}, "Template", "Strategy"))
 }
 
 func lateInit(observed v1alpha1.DatabaseParameters, desired *v1alpha1.DatabaseParameters) bool {

--- a/pkg/controller/cluster/postgresql/database/reconciler_test.go
+++ b/pkg/controller/cluster/postgresql/database/reconciler_test.go
@@ -58,6 +58,10 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 	return m.MockGetConnectionDetails(username, password)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
 	nopUsage := func(ctx context.Context, mg resource.LegacyManaged) error { return nil }
@@ -269,8 +273,9 @@ func TestCreate(t *testing.T) {
 	}
 
 	type want struct {
-		c   managed.ExternalCreation
-		err error
+		c     managed.ExternalCreation
+		err   error
+		query string
 	}
 
 	cases := map[string]struct {
@@ -321,10 +326,69 @@ func TestCreate(t *testing.T) {
 				err: nil,
 			},
 		},
+		"SuccessWithStrategy": {
+			reason: "The CREATE statement should include STRATEGY when specified",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = minDatabaseStrategyServerVersion
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							Template: ptr("template-source"),
+							Strategy: ptr(v1alpha1.DatabaseStrategyFileCopy),
+						},
+					},
+				},
+			},
+			want: want{
+				err:   nil,
+				query: `CREATE DATABASE "" TEMPLATE "template-source" STRATEGY FILE_COPY`,
+			},
+		},
+		"ErrUnsupportedStrategyVersion": {
+			reason: "An error should be returned when strategy is requested on PostgreSQL versions older than 15",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = 140000
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							Strategy: ptr(v1alpha1.DatabaseStrategyFileCopy),
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Errorf("database strategy requires PostgreSQL 15+; found server_version_num=%d", 140000), errCreateDB),
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			var lastQuery string
+			if tc.want.query != "" {
+				origDB := tc.fields.db.(*mockDB)
+				origExec := origDB.MockExec
+				origDB.MockExec = func(ctx context.Context, q xsql.Query) error {
+					lastQuery = q.String
+					return origExec(ctx, q)
+				}
+			}
 			e := external{db: tc.fields.db}
 			got, err := e.Create(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -332,6 +396,11 @@ func TestCreate(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.c, got); diff != "" {
 				t.Errorf("\n%s\ne.Create(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+			if tc.want.query != "" {
+				if diff := cmp.Diff(tc.want.query, lastQuery); diff != "" {
+					t.Errorf("\n%s\ne.Create(...): -want query, +got query:\n%s\n", tc.reason, diff)
+				}
 			}
 		})
 	}

--- a/pkg/controller/namespaced/postgresql/database/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/database/reconciler.go
@@ -49,6 +49,7 @@ const (
 	errTrackPCUsage = "cannot track ProviderConfig usage"
 
 	errSelectDB          = "cannot select database"
+	errSelectServerVer   = "cannot determine PostgreSQL server version"
 	errCreateDB          = "cannot create database"
 	errAlterDBOwner      = "cannot alter database owner"
 	errAlterDBConnLimit  = "cannot alter database connection limit"
@@ -56,7 +57,8 @@ const (
 	errAlterDBIsTmpl     = "cannot alter database is template"
 	errDropDB            = "cannot drop database"
 
-	maxConcurrency = 5
+	maxConcurrency                   = 5
+	minDatabaseStrategyServerVersion = 150000
 )
 
 // Setup adds a controller that reconciles Database managed resources.
@@ -178,6 +180,11 @@ func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Database)
 func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalCreation, error) { //nolint:gocyclo
 	// NOTE(negz): This is only a tiny bit over our cyclomatic complexity limit,
 	// and more readable than if we refactored it to avoid the linter error.
+	if mg.Spec.ForProvider.Strategy != nil {
+		if err := c.ensureDatabaseStrategySupport(ctx); err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, errCreateDB)
+		}
+	}
 
 	var b strings.Builder
 	b.WriteString("CREATE DATABASE ")
@@ -190,6 +197,10 @@ func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Database) 
 	if mg.Spec.ForProvider.Template != nil {
 		b.WriteString(" TEMPLATE ")
 		b.WriteString(quoteIfIdentifier(*mg.Spec.ForProvider.Template))
+	}
+	if mg.Spec.ForProvider.Strategy != nil {
+		b.WriteString(" STRATEGY ")
+		b.WriteString(string(*mg.Spec.ForProvider.Strategy))
 	}
 	if mg.Spec.ForProvider.Encoding != nil {
 		b.WriteString(" ENCODING ")
@@ -218,6 +229,18 @@ func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Database) 
 	}
 
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: b.String()}), errCreateDB)
+}
+
+func (c *external) ensureDatabaseStrategySupport(ctx context.Context) error {
+	var serverVersion int
+	err := c.db.Scan(ctx, xsql.Query{String: "SELECT current_setting('server_version_num')::integer"}, &serverVersion)
+	if err != nil {
+		return errors.Wrap(err, errSelectServerVer)
+	}
+	if serverVersion < minDatabaseStrategyServerVersion {
+		return errors.Errorf("database strategy requires PostgreSQL 15+; found server_version_num=%d", serverVersion)
+	}
+	return nil
 }
 
 func (c *external) Update(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalUpdate, error) { //nolint:gocyclo
@@ -273,8 +296,8 @@ func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Database) 
 }
 
 func upToDate(observed, desired namespacedv1alpha1.DatabaseParameters) bool {
-	// Template is only used at create time.
-	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(namespacedv1alpha1.DatabaseParameters{}, "Template"))
+	// Template and strategy are only used at create time.
+	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(namespacedv1alpha1.DatabaseParameters{}, "Template", "Strategy"))
 }
 
 func lateInit(observed namespacedv1alpha1.DatabaseParameters, desired *namespacedv1alpha1.DatabaseParameters) bool {

--- a/pkg/controller/namespaced/postgresql/database/reconciler_test.go
+++ b/pkg/controller/namespaced/postgresql/database/reconciler_test.go
@@ -61,6 +61,10 @@ func (m mockDB) GetConnectionDetails(username, password string) managed.Connecti
 	return m.MockGetConnectionDetails(username, password)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestConnect(t *testing.T) {
 	errBoom := errors.New("boom")
 
@@ -327,8 +331,9 @@ func TestCreate(t *testing.T) {
 	}
 
 	type want struct {
-		c   managed.ExternalCreation
-		err error
+		c     managed.ExternalCreation
+		err   error
+		query string
 	}
 
 	cases := map[string]struct {
@@ -379,10 +384,69 @@ func TestCreate(t *testing.T) {
 				err: nil,
 			},
 		},
+		"SuccessWithStrategy": {
+			reason: "The CREATE statement should include STRATEGY when specified",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = minDatabaseStrategyServerVersion
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							Template: ptr("template-source"),
+							Strategy: ptr(v1alpha1.DatabaseStrategyFileCopy),
+						},
+					},
+				},
+			},
+			want: want{
+				err:   nil,
+				query: `CREATE DATABASE "" TEMPLATE "template-source" STRATEGY FILE_COPY`,
+			},
+		},
+		"ErrUnsupportedStrategyVersion": {
+			reason: "An error should be returned when strategy is requested on PostgreSQL versions older than 15",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = 140000
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							Strategy: ptr(v1alpha1.DatabaseStrategyFileCopy),
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Errorf("database strategy requires PostgreSQL 15+; found server_version_num=%d", 140000), errCreateDB),
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			var lastQuery string
+			if tc.want.query != "" {
+				origDB := tc.fields.db.(*mockDB)
+				origExec := origDB.MockExec
+				origDB.MockExec = func(ctx context.Context, q xsql.Query) error {
+					lastQuery = q.String
+					return origExec(ctx, q)
+				}
+			}
 			e := external{db: tc.fields.db}
 			got, err := e.Create(tc.args.ctx, tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
@@ -390,6 +454,11 @@ func TestCreate(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.c, got); diff != "" {
 				t.Errorf("\n%s\ne.Create(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+			if tc.want.query != "" {
+				if diff := cmp.Diff(tc.want.query, lastQuery); diff != "" {
+					t.Errorf("\n%s\ne.Create(...): -want query, +got query:\n%s\n", tc.reason, diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Add PostgreSQL Database strategy support for template-based database creation and make its lifecycle explicit in the API. The new strategy field is treated as create-time-only, and validated so updates do not silently drift from the real database state.

Fail fast when strategy is requested against PostgreSQL versions older than 15 instead of letting CREATE DATABASE fail with a less clear SQL error.

Fixes #341

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- run test-integration
- local testing 