### PR TITLE
chore: e2e: remove redundant mariadb e2e tests

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -445,7 +445,6 @@ run_test() {
   echo_step "--- TESTING $testmain DONE IN ${duration}s ---"
 }
 
-TLS=true API_TYPE="cluster" run_test integration_tests_mariadb
 TLS=true API_TYPE="namespaced" run_test integration_tests_mariadb
 TLS=false API_TYPE="cluster" run_test integration_tests_mariadb
 


### PR DESCRIPTION
### Description of your changes

Remove extra mariadb e2e tests.

The difference between TLS and non-TLS doesn't make it worth running
both on e2e. We already try both in cluster vs namespaced mode.

Fixes slow CI

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

make e2e

[contribution process]: https://git.io/fj2m9
