### PR TITLE
feat(postgresql): add forceDrop option to DROP DATABASE

### DIFF
--- a/apis/cluster/postgresql/v1alpha1/database_types.go
+++ b/apis/cluster/postgresql/v1alpha1/database_types.go
@@ -52,6 +52,16 @@ type DatabaseParameters struct {
 	// +optional
 	Strategy *DatabaseStrategy `json:"strategy,omitempty"`
 
+	// ForceDrop controls whether the database is dropped with the WITH (FORCE)
+	// option, which terminates every existing connection to the database
+	// before dropping it. This is useful when an application (e.g. a long-lived
+	// connection pool) keeps the database in use and would otherwise cause the
+	// drop to fail with SQLSTATE 55006 (object_in_use).
+	// This field only affects deletion and requires PostgreSQL 13+.
+	// Defaults to false.
+	// +optional
+	ForceDrop *bool `json:"forceDrop,omitempty"`
+
 	// Character set encoding to use in the new database. Specify a string
 	// constant (e.g., 'SQL_ASCII'), or an integer encoding number, or DEFAULT
 	// to use the default encoding (namely, the encoding of the template

--- a/apis/cluster/postgresql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/postgresql/v1alpha1/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *DatabaseParameters) DeepCopyInto(out *DatabaseParameters) {
 		*out = new(DatabaseStrategy)
 		**out = **in
 	}
+	if in.ForceDrop != nil {
+		in, out := &in.ForceDrop, &out.ForceDrop
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Encoding != nil {
 		in, out := &in.Encoding, &out.Encoding
 		*out = new(string)

--- a/apis/namespaced/postgresql/v1alpha1/database_types.go
+++ b/apis/namespaced/postgresql/v1alpha1/database_types.go
@@ -53,6 +53,16 @@ type DatabaseParameters struct {
 	// +optional
 	Strategy *DatabaseStrategy `json:"strategy,omitempty"`
 
+	// ForceDrop controls whether the database is dropped with the WITH (FORCE)
+	// option, which terminates every existing connection to the database
+	// before dropping it. This is useful when an application (e.g. a long-lived
+	// connection pool) keeps the database in use and would otherwise cause the
+	// drop to fail with SQLSTATE 55006 (object_in_use).
+	// This field only affects deletion and requires PostgreSQL 13+.
+	// Defaults to false.
+	// +optional
+	ForceDrop *bool `json:"forceDrop,omitempty"`
+
 	// Character set encoding to use in the new database. Specify a string
 	// constant (e.g., 'SQL_ASCII'), or an integer encoding number, or DEFAULT
 	// to use the default encoding (namely, the encoding of the template

--- a/apis/namespaced/postgresql/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/postgresql/v1alpha1/zz_generated.deepcopy.go
@@ -207,6 +207,11 @@ func (in *DatabaseParameters) DeepCopyInto(out *DatabaseParameters) {
 		*out = new(DatabaseStrategy)
 		**out = **in
 	}
+	if in.ForceDrop != nil {
+		in, out := &in.ForceDrop, &out.ForceDrop
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Encoding != nil {
 		in, out := &in.Encoding, &out.Encoding
 		*out = new(string)

--- a/examples/cluster/postgresql/database-forcedrop.yaml
+++ b/examples/cluster/postgresql/database-forcedrop.yaml
@@ -1,0 +1,12 @@
+apiVersion: postgresql.sql.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: force-drop-db
+spec:
+  forProvider:
+    # Optional, only affects deletion, and supported on PostgreSQL 13+.
+    # When true, DROP DATABASE is issued with WITH (FORCE), which terminates
+    # every existing connection before dropping the database. Useful when an
+    # application keeps a long-lived connection pool open against the database,
+    # which would otherwise make the drop fail with SQLSTATE 55006 (object_in_use).
+    forceDrop: true

--- a/examples/namespaced/postgresql/database-forcedrop.yaml
+++ b/examples/namespaced/postgresql/database-forcedrop.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: force-drop-db
+  namespace: default
+spec:
+  forProvider:
+    # Optional, only affects deletion, and supported on PostgreSQL 13+.
+    # When true, DROP DATABASE is issued with WITH (FORCE), which terminates
+    # every existing connection before dropping the database. Useful when an
+    # application keeps a long-lived connection pool open against the database,
+    # which would otherwise make the drop fail with SQLSTATE 55006 (object_in_use).
+    forceDrop: true
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default

--- a/package/crds/postgresql.sql.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_databases.yaml
@@ -89,6 +89,16 @@ spec:
                       database). The character sets supported by the PostgreSQL server are
                       described in Section 23.3.1. See below for additional restrictions.
                     type: string
+                  forceDrop:
+                    description: |-
+                      ForceDrop controls whether the database is dropped with the WITH (FORCE)
+                      option, which terminates every existing connection to the database
+                      before dropping it. This is useful when an application (e.g. a long-lived
+                      connection pool) keeps the database in use and would otherwise cause the
+                      drop to fail with SQLSTATE 55006 (object_in_use).
+                      This field only affects deletion and requires PostgreSQL 13+.
+                      Defaults to false.
+                    type: boolean
                   isTemplate:
                     description: |-
                       If true, then this database can be cloned by any user with CREATEDB

--- a/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
@@ -75,6 +75,16 @@ spec:
                       database). The character sets supported by the PostgreSQL server are
                       described in Section 23.3.1. See below for additional restrictions.
                     type: string
+                  forceDrop:
+                    description: |-
+                      ForceDrop controls whether the database is dropped with the WITH (FORCE)
+                      option, which terminates every existing connection to the database
+                      before dropping it. This is useful when an application (e.g. a long-lived
+                      connection pool) keeps the database in use and would otherwise cause the
+                      drop to fail with SQLSTATE 55006 (object_in_use).
+                      This field only affects deletion and requires PostgreSQL 13+.
+                      Defaults to false.
+                    type: boolean
                   isTemplate:
                     description: |-
                       If true, then this database can be cloned by any user with CREATEDB

--- a/pkg/controller/cluster/postgresql/database/reconciler.go
+++ b/pkg/controller/cluster/postgresql/database/reconciler.go
@@ -61,8 +61,9 @@ const (
 	errAlterDBIsTmpl     = "cannot alter database is template"
 	errDropDB            = "cannot drop database"
 
-	maxConcurrency                   = 5
-	minDatabaseStrategyServerVersion = 150000
+	maxConcurrency                    = 5
+	minDatabaseStrategyServerVersion  = 150000
+	minDatabaseForceDropServerVersion = 130000
 )
 
 // Setup adds a controller that reconciles Database managed resources.
@@ -260,6 +261,20 @@ func (c *external) ensureDatabaseStrategySupport(ctx context.Context) error {
 	return nil
 }
 
+// ensureDatabaseForceDropSupport verifies that the server supports the
+// WITH (FORCE) option of DROP DATABASE, which was introduced in PostgreSQL 13.
+func (c *external) ensureDatabaseForceDropSupport(ctx context.Context) error {
+	var serverVersion int
+	err := c.db.Scan(ctx, xsql.Query{String: "SELECT current_setting('server_version_num')::integer"}, &serverVersion)
+	if err != nil {
+		return errors.Wrap(err, errSelectServerVer)
+	}
+	if serverVersion < minDatabaseForceDropServerVersion {
+		return errors.Errorf("forceDrop requires PostgreSQL 13+; found server_version_num=%d", serverVersion)
+	}
+	return nil
+}
+
 func (c *external) Update(ctx context.Context, mg *v1alpha1.Database) (managed.ExternalUpdate, error) { //nolint:gocyclo
 	// NOTE(negz): This is only a tiny bit over our cyclomatic complexity limit,
 	// and more readable than if we refactored it to avoid the linter error.
@@ -308,13 +323,27 @@ func (c *external) Disconnect(ctx context.Context) error {
 }
 
 func (c *external) Delete(ctx context.Context, mg *v1alpha1.Database) (managed.ExternalDelete, error) {
-	err := c.db.Exec(ctx, xsql.Query{String: "DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(mg))})
-	return managed.ExternalDelete{}, errors.Wrap(err, errDropDB)
+	query := "DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(mg))
+
+	// The WITH (FORCE) option terminates every existing backend connected to
+	// the target database before dropping it. It was introduced in PostgreSQL
+	// 13 and is required to drop a database that still has open connections
+	// (e.g. a long-lived application connection pool), which would otherwise
+	// fail with SQLSTATE 55006 (object_in_use).
+	if mg.Spec.ForProvider.ForceDrop != nil && *mg.Spec.ForProvider.ForceDrop {
+		if err := c.ensureDatabaseForceDropSupport(ctx); err != nil {
+			return managed.ExternalDelete{}, errors.Wrap(err, errDropDB)
+		}
+		query += " WITH (FORCE)"
+	}
+
+	return managed.ExternalDelete{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: query}), errDropDB)
 }
 
 func upToDate(observed, desired v1alpha1.DatabaseParameters) bool {
-	// Template and strategy are only used at create time.
-	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(v1alpha1.DatabaseParameters{}, "Template", "Strategy"))
+	// Template and strategy are only used at create time, and forceDrop only
+	// affects deletion. None of them are observable properties of the database.
+	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(v1alpha1.DatabaseParameters{}, "Template", "Strategy", "ForceDrop"))
 }
 
 func lateInit(observed v1alpha1.DatabaseParameters, desired *v1alpha1.DatabaseParameters) bool {

--- a/pkg/controller/cluster/postgresql/database/reconciler_test.go
+++ b/pkg/controller/cluster/postgresql/database/reconciler_test.go
@@ -575,11 +575,16 @@ func TestDelete(t *testing.T) {
 		mg  *v1alpha1.Database
 	}
 
+	type want struct {
+		err   error
+		query string
+	}
+
 	cases := map[string]struct {
 		reason string
 		fields fields
 		args   args
-		want   error
+		want   want
 	}{
 		"ErrDropDB": {
 			reason: "Errors dropping a database should be returned",
@@ -593,16 +598,94 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Database{},
 			},
-			want: errors.Wrap(errBoom, errDropDB),
+			want: want{
+				err: errors.Wrap(errBoom, errDropDB),
+			},
+		},
+		"Success": {
+			reason: "A bare DROP DATABASE statement should be issued by default",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{},
+			},
+			want: want{
+				query: `DROP DATABASE IF EXISTS ""`,
+			},
+		},
+		"SuccessWithForce": {
+			reason: "The DROP statement should include WITH (FORCE) when requested",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = minDatabaseForceDropServerVersion
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							ForceDrop: ptr(true),
+						},
+					},
+				},
+			},
+			want: want{
+				query: `DROP DATABASE IF EXISTS "" WITH (FORCE)`,
+			},
+		},
+		"ErrUnsupportedForceVersion": {
+			reason: "An error should be returned when forceDrop is requested on PostgreSQL versions older than 13",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = 120000
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							ForceDrop: ptr(true),
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Errorf("forceDrop requires PostgreSQL 13+; found server_version_num=%d", 120000), errDropDB),
+			},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			var lastQuery string
+			if tc.want.query != "" {
+				origDB := tc.fields.db.(*mockDB)
+				origExec := origDB.MockExec
+				origDB.MockExec = func(ctx context.Context, q xsql.Query) error {
+					lastQuery = q.String
+					return origExec(ctx, q)
+				}
+			}
 			e := external{db: tc.fields.db}
 			_, err := e.Delete(tc.args.ctx, tc.args.mg)
-			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Delete(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if tc.want.query != "" {
+				if diff := cmp.Diff(tc.want.query, lastQuery); diff != "" {
+					t.Errorf("\n%s\ne.Delete(...): -want query, +got query:\n%s\n", tc.reason, diff)
+				}
 			}
 		})
 	}

--- a/pkg/controller/namespaced/postgresql/database/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/database/reconciler.go
@@ -57,8 +57,9 @@ const (
 	errAlterDBIsTmpl     = "cannot alter database is template"
 	errDropDB            = "cannot drop database"
 
-	maxConcurrency                   = 5
-	minDatabaseStrategyServerVersion = 150000
+	maxConcurrency                    = 5
+	minDatabaseStrategyServerVersion  = 150000
+	minDatabaseForceDropServerVersion = 130000
 )
 
 // Setup adds a controller that reconciles Database managed resources.
@@ -243,6 +244,20 @@ func (c *external) ensureDatabaseStrategySupport(ctx context.Context) error {
 	return nil
 }
 
+// ensureDatabaseForceDropSupport verifies that the server supports the
+// With (FORCE) option of DROP DATABASE, which was introduced in PostgreSQL 13.
+func (c *external) ensureDatabaseForceDropSupport(ctx context.Context) error {
+	var serverVersion int
+	err := c.db.Scan(ctx, xsql.Query{String: "SELECT current_setting('server_version_num')::integer"}, &serverVersion)
+	if err != nil {
+		return errors.Wrap(err, errSelectServerVer)
+	}
+	if serverVersion < minDatabaseForceDropServerVersion {
+		return errors.Errorf("forceDrop requires PostgreSQL 13+; found server_version_num=%d", serverVersion)
+	}
+	return nil
+}
+
 func (c *external) Update(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalUpdate, error) { //nolint:gocyclo
 	// NOTE(negz): This is only a tiny bit over our cyclomatic complexity limit,
 	// and more readable than if we refactored it to avoid the linter error.
@@ -291,13 +306,27 @@ func (c *external) Disconnect(ctx context.Context) error {
 }
 
 func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Database) (managed.ExternalDelete, error) {
-	err := c.db.Exec(ctx, xsql.Query{String: "DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(mg))})
-	return managed.ExternalDelete{}, errors.Wrap(err, errDropDB)
+	query := "DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(mg))
+
+	// The WITH (FORCE) option terminates every existing backend connected to
+	// the target database before dropping it. It was introduced in PostgreSQL
+	// 13 and is required to drop a database that still has open connections
+	// (e.g. a long-lived application connection pool), which would otherwise
+	// fail with SQLSTATE 55006 (object_in_use).
+	if mg.Spec.ForProvider.ForceDrop != nil && *mg.Spec.ForProvider.ForceDrop {
+		if err := c.ensureDatabaseForceDropSupport(ctx); err != nil {
+			return managed.ExternalDelete{}, errors.Wrap(err, errDropDB)
+		}
+		query += " WITH (FORCE)"
+	}
+
+	return managed.ExternalDelete{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: query}), errDropDB)
 }
 
 func upToDate(observed, desired namespacedv1alpha1.DatabaseParameters) bool {
-	// Template and strategy are only used at create time.
-	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(namespacedv1alpha1.DatabaseParameters{}, "Template", "Strategy"))
+	// Template and strategy are only used at create time, and forceDrop only
+	// affects deletion. None of them are observable properties of the database.
+	return cmp.Equal(desired, observed, cmpopts.IgnoreFields(namespacedv1alpha1.DatabaseParameters{}, "Template", "Strategy", "ForceDrop"))
 }
 
 func lateInit(observed namespacedv1alpha1.DatabaseParameters, desired *namespacedv1alpha1.DatabaseParameters) bool {

--- a/pkg/controller/namespaced/postgresql/database/reconciler_test.go
+++ b/pkg/controller/namespaced/postgresql/database/reconciler_test.go
@@ -634,11 +634,16 @@ func TestDelete(t *testing.T) {
 		mg  *v1alpha1.Database
 	}
 
+	type want struct {
+		err   error
+		query string
+	}
+
 	cases := map[string]struct {
 		reason string
 		fields fields
 		args   args
-		want   error
+		want   want
 	}{
 		"ErrDropDB": {
 			reason: "Errors dropping a database should be returned",
@@ -652,16 +657,94 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.Database{},
 			},
-			want: errors.Wrap(errBoom, errDropDB),
+			want: want{
+				err: errors.Wrap(errBoom, errDropDB),
+			},
+		},
+		"Success": {
+			reason: "A bare DROP DATABASE statement should be issued by default",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{},
+			},
+			want: want{
+				query: `DROP DATABASE IF EXISTS ""`,
+			},
+		},
+		"SuccessWithForce": {
+			reason: "The DROP statement should include WITH (FORCE) when requested",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = minDatabaseForceDropServerVersion
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							ForceDrop: ptr(true),
+						},
+					},
+				},
+			},
+			want: want{
+				query: `DROP DATABASE IF EXISTS "" WITH (FORCE)`,
+			},
+		},
+		"ErrUnsupportedForceVersion": {
+			reason: "An error should be returned when forceDrop is requested on PostgreSQL versions older than 13",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*(dest[0].(*int)) = 120000
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Database{
+					Spec: v1alpha1.DatabaseSpec{
+						ForProvider: v1alpha1.DatabaseParameters{
+							ForceDrop: ptr(true),
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Errorf("forceDrop requires PostgreSQL 13+; found server_version_num=%d", 120000), errDropDB),
+			},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			var lastQuery string
+			if tc.want.query != "" {
+				origDB := tc.fields.db.(*mockDB)
+				origExec := origDB.MockExec
+				origDB.MockExec = func(ctx context.Context, q xsql.Query) error {
+					lastQuery = q.String
+					return origExec(ctx, q)
+				}
+			}
 			e := external{db: tc.fields.db}
 			_, err := e.Delete(tc.args.ctx, tc.args.mg)
-			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ne.Delete(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if tc.want.query != "" {
+				if diff := cmp.Diff(tc.want.query, lastQuery); diff != "" {
+					t.Errorf("\n%s\ne.Delete(...): -want query, +got query:\n%s\n", tc.reason, diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds an opt-in `forceDrop` field to the PostgreSQL `Database` managed
resource that makes the controller issue `DROP DATABASE IF EXISTS <name>
WITH (FORCE)` instead of a bare drop. Applies to both the cluster-scoped
(`postgresql.sql.crossplane.io`) and namespaced
(`postgresql.sql.m.crossplane.io`) APIs.

`WITH (FORCE)` (PostgreSQL 13+) terminates every backend connected to
the target database before dropping it. Without it, a `Database` with
`deletionPolicy: Delete` cannot be removed while any client holds an
open connection, because the bare drop fails with SQLSTATE `55006`
(`object_in_use`). The managed resource then sticks `Terminating`
indefinitely — i.e. provider-sql cannot delete what it created whenever
an application maintains a persistent connection pool against the
database.

Today, `Database.Delete` is:

```go
err := c.db.Exec(ctx, xsql.Query{String: "DROP DATABASE IF EXISTS " + pq.QuoteIdentifier(meta.GetExternalName(mg))})
```

This adds the `WITH (FORCE)` escape hatch so a declarative
`deletionPolicy: Delete` works even with a live pool.

## Design

- New optional boolean `spec.forProvider.forceDrop` (defaults to
  omitted/false → behaviour unchanged).
- When true, `Delete` appends ` WITH (FORCE)`.
- Version-gated on PostgreSQL 13+ (`server_version_num >= 130000`),
  returning a clear error otherwise. This mirrors the existing
  create-time `strategy` version guard.
- `forceDrop` is a delete-only behaviour toggle, not an observable
  property of the database, so it is added to the `upToDate` ignore list
  alongside `template` and `strategy` (no reconciliation churn).

### Open questions for reviewers

- **Error vs. fallback on PG < 13.** This PR errors when `forceDrop` is
  requested on a server older than 13, matching `strategy`. A gentler
  alternative would be to fall back to a `pg_terminate_backend` drain
  step (works on all versions) when `WITH (FORCE)` is unavailable. Happy
  to switch to that if preferred. Note PostgreSQL 13 reached EOL in Nov
  2025, so most deployments are already on 14+.
- **Naming.** Went with `forceDrop` to map directly to the SQL keyword
  and stay consistent with the existing camelCase field style. Open to
  `force` / `forceDelete` if there's a preferred convention.

## Validation

- CRDs and deepcopy regenerated via `controller-gen`.
- Unit tests added for: default bare drop, `WITH (FORCE)` drop, and the
  unsupported-version error path (cluster + namespaced).
- `gofmt`, `go vet`, `go build ./...`, and `go test ./...` all pass.

## Example

```yaml
apiVersion: postgresql.sql.crossplane.io/v1alpha1
kind: Database
metadata:
  name: force-drop-db
spec:
  forProvider:
    # Optional, only affects deletion, PostgreSQL 13+.
    forceDrop: true
```