### PR TITLE
fix(postgresql/database): drop optionalOldSelf from strategy immutability rule

### DIFF
--- a/apis/cluster/postgresql/v1alpha1/database_types.go
+++ b/apis/cluster/postgresql/v1alpha1/database_types.go
@@ -33,7 +33,7 @@ const (
 )
 
 // DatabaseParameters are the configurable fields of a Database.
-// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy)) || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy == oldSelf.value().strategy))",message="strategy field is immutable after creation",optionalOldSelf=true
+// +kubebuilder:validation:XValidation:rule="(!has(self.strategy) && !has(oldSelf.strategy)) || (has(self.strategy) && has(oldSelf.strategy) && self.strategy == oldSelf.strategy)",message="strategy field is immutable after creation"
 type DatabaseParameters struct {
 	// The role name of the user who will own the new database, or DEFAULT to
 	// use the default (namely, the user executing the command). To create a

--- a/apis/namespaced/postgresql/v1alpha1/database_types.go
+++ b/apis/namespaced/postgresql/v1alpha1/database_types.go
@@ -34,7 +34,7 @@ const (
 )
 
 // DatabaseParameters are the configurable fields of a Database.
-// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy)) || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy == oldSelf.value().strategy))",message="strategy field is immutable after creation",optionalOldSelf=true
+// +kubebuilder:validation:XValidation:rule="(!has(self.strategy) && !has(oldSelf.strategy)) || (has(self.strategy) && has(oldSelf.strategy) && self.strategy == oldSelf.strategy)",message="strategy field is immutable after creation"
 type DatabaseParameters struct {
 	// The role name of the user who will own the new database, or DEFAULT to
 	// use the default (namely, the user executing the command). To create a

--- a/package/crds/postgresql.sql.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_databases.yaml
@@ -217,10 +217,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: strategy field is immutable after creation
-                  optionalOldSelf: true
-                  rule: '!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy))
-                    || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy
-                    == oldSelf.value().strategy))'
+                  rule: (!has(self.strategy) && !has(oldSelf.strategy)) || (has(self.strategy)
+                    && has(oldSelf.strategy) && self.strategy == oldSelf.strategy)
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
+++ b/package/crds/postgresql.sql.m.crossplane.io_databases.yaml
@@ -209,10 +209,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: strategy field is immutable after creation
-                  optionalOldSelf: true
-                  rule: '!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy))
-                    || (has(self.strategy) && has(oldSelf.value().strategy) && self.strategy
-                    == oldSelf.value().strategy))'
+                  rule: (!has(self.strategy) && !has(oldSelf.strategy)) || (has(self.strategy)
+                    && has(oldSelf.strategy) && self.strategy == oldSelf.strategy)
               managementPolicies:
                 default:
                 - '*'


### PR DESCRIPTION
### Description of your changes

Fixes #409.

The `strategy`-immutability validation on the postgres `Database` `DatabaseParameters` (added in #343) is generated with `optionalOldSelf=true`:

```
!oldSelf.hasValue() || ((!has(self.strategy) && !has(oldSelf.value().strategy))
 || (has(self.strategy) && has(oldSelf.value().strategy)
     && self.strategy == oldSelf.value().strategy))
```

`optionalOldSelf` (the `oldSelf.hasValue()` / `oldSelf.value()` form) requires a newer API-server CEL environment. On API servers that don't honor it (e.g. older EKS platform builds such as `v1.31.14-eks-0690643`, and 1.30.x clusters), `oldSelf` is not wrapped as an optional, so `hasValue()`/`value()` have no matching overload, the CEL rule fails to compile, and the whole CRD is rejected:

```
...x-kubernetes-validations[0].rule: compilation failed:
ERROR found no matching overload for 'hasValue' applied to 'selfType...'
```

When that happens the `ProviderRevision` cannot establish control and provider-sql fails to install on the affected cluster.

Because the rule is a **transition rule** (it references `oldSelf`), it only runs on UPDATE, where `oldSelf` is always present — so `optionalOldSelf` is unnecessary. This PR replaces it with a plain presence-aware transition rule that compiles on all Kubernetes >= 1.25:

```
(!has(self.strategy) && !has(oldSelf.strategy)) ||
(has(self.strategy) && has(oldSelf.strategy) && self.strategy == oldSelf.strategy)
```

Applied to both the cluster (v1, `postgresql.sql.crossplane.io`) and namespaced (v2, `postgresql.sql.m.crossplane.io`) Database types, and regenerated the CRDs. The regenerated CRD YAML contains no `optionalOldSelf`.

**Note for the #343 authors:** `optionalOldSelf` also permits a rule to run at CREATE (where there is no `oldSelf`). The "immutable after creation" intent only needs UPDATE-time enforcement, so a transition rule is correct — but flagging in case the original rule was intended to also reject something at CREATE.

### I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Server-side dry-run apply of the regenerated `Database` CRDs succeeds on an affected older-EKS-build cluster (`v1.31.14-eks-0690643`) where the previous `optionalOldSelf` rule failed to compile; and continues to install on newer builds. `make generate` regenerates the CRDs with the new rule and no `optionalOldSelf`.

[contribution process]: https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md
