### PR TITLE
fix: allow multiple users to share the same login

### DIFF
--- a/cluster/local/mssqldb_functions.sh
+++ b/cluster/local/mssqldb_functions.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+MSSQL_IMAGE="${MSSQL_IMAGE:-mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04}"
+
 setup_mssql() {
-  echo_step "installing MSSQL Server"
+  echo_step "installing MSSQL Server (image ${MSSQL_IMAGE})"
 
   "${KUBECTL}" create secret generic mssql-creds \
       --from-literal username="sa" \
@@ -13,7 +15,8 @@ setup_mssql() {
   echo_step "Verifying secret creation"
   "${KUBECTL}" get secret mssql-creds -o yaml
 
-  "${KUBECTL}" apply -f ${scriptdir}/mssql.server.yaml
+  sed "s|image: mcr.microsoft.com/mssql/server:.*|image: ${MSSQL_IMAGE}|" \
+      "${scriptdir}/mssql.server.yaml" | "${KUBECTL}" apply -f -
 
   echo_step "Waiting for MSSQL Server to be ready"
   "${KUBECTL}" rollout status statefulset/mssql --timeout=300s
@@ -86,11 +89,50 @@ test_create_mssql_grant() {
   echo_step_completed
 }
 
+test_create_mssql_shared_login_users() {
+  echo_step "test creating MSSQL Users sharing a login across two databases (issue #288)"
+
+  "${KUBECTL}" create secret generic shared-login-pw \
+      --from-literal password="Shared123!" --dry-run=client -o yaml | "${KUBECTL}" apply -f -
+
+  "${KUBECTL}" apply -f ${projectdir}/examples/${API_TYPE}/mssql/user-shared-login.yaml
+
+  echo_step "Waiting for db1/db2 to be ready"
+  "${KUBECTL}" wait --timeout 2m --for condition=Ready \
+      database.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/db1 \
+      database.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/db2
+
+  echo_step "Waiting for both shared-login Users to be ready"
+  # Before the fix the second User is stuck with "server principal already exists".
+  "${KUBECTL}" wait --timeout 2m --for condition=Ready \
+      user.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/shared-login-user-db1 \
+      user.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/shared-login-user-db2
+  echo_step_completed
+
+  # DROP LOGIN guard: enable deletion (examples orphan) and delete sequentially -
+  # the second delete must not error now that the shared login is already gone.
+  echo_step "test delete guard: sequential deletion does not error on the shared login"
+  local enable_delete
+  if [ "${API_TYPE}" == "namespaced" ]; then
+    enable_delete='{"spec":{"managementPolicies":["*"]}}'
+  else
+    enable_delete='{"spec":{"deletionPolicy":"Delete"}}'
+  fi
+  for u in shared-login-user-db1 shared-login-user-db2; do
+    "${KUBECTL}" patch user.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/$u \
+        --type merge -p "${enable_delete}"
+    "${KUBECTL}" delete user.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/$u
+    "${KUBECTL}" wait --for=delete user.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/$u --timeout=90s
+  done
+  echo_step_completed
+}
+
 test_mssql_all() {
   test_create_mssql_database
   test_create_mssql_user
   test_update_mssql_user_password
   test_create_mssql_grant
+  test_create_mssql_shared_login_users
 }
 
 cleanup_mssql_test_resources() {
@@ -100,6 +142,12 @@ cleanup_mssql_test_resources() {
 
   "${KUBECTL}" delete -f ${projectdir}/examples/${API_TYPE}/mssql/user.yaml --ignore-not-found=true
   "${KUBECTL}" wait --for=delete user.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/example-user --timeout=60s
+
+  # Users already deleted by the test; this removes db1/db2 and the secret.
+  "${KUBECTL}" delete -f ${projectdir}/examples/${API_TYPE}/mssql/user-shared-login.yaml --ignore-not-found=true
+  "${KUBECTL}" wait --for=delete database.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/db1 --timeout=60s
+  "${KUBECTL}" wait --for=delete database.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/db2 --timeout=60s
+  "${KUBECTL}" delete secret shared-login-pw --ignore-not-found=true
 
   "${KUBECTL}" delete -f ${projectdir}/examples/${API_TYPE}/mssql/database.yaml --ignore-not-found=true
   "${KUBECTL}" wait --for=delete database.mssql.sql.${APIGROUP_SUFFIX}crossplane.io/example-db --timeout=60s

--- a/examples/cluster/mssql/user-shared-login.yaml
+++ b/examples/cluster/mssql/user-shared-login.yaml
@@ -1,0 +1,54 @@
+# Shared login across databases: one User per database sharing the same
+# external-name (login/user name), passwordSecretRef and loginDatabase: master.
+# CREATE LOGIN only runs when the login is absent, so the second User reuses it.
+# Orphan these Users so deleting one does not drop the shared login and break
+# its sibling.
+apiVersion: mssql.sql.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: db1
+spec: {}
+---
+apiVersion: mssql.sql.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: db2
+spec: {}
+---
+apiVersion: mssql.sql.crossplane.io/v1alpha1
+kind: User
+metadata:
+  name: shared-login-user-db1
+  annotations:
+    crossplane.io/external-name: shared-login-user
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    database: db1
+    loginDatabase: master
+    passwordSecretRef:
+      name: shared-login-pw
+      namespace: default
+      key: password
+  writeConnectionSecretToRef:
+    name: shared-login-user-db1-connection-secret
+    namespace: default
+---
+apiVersion: mssql.sql.crossplane.io/v1alpha1
+kind: User
+metadata:
+  name: shared-login-user-db2
+  annotations:
+    crossplane.io/external-name: shared-login-user
+spec:
+  deletionPolicy: Orphan
+  forProvider:
+    database: db2
+    loginDatabase: master
+    passwordSecretRef:
+      name: shared-login-pw
+      namespace: default
+      key: password
+  writeConnectionSecretToRef:
+    name: shared-login-user-db2-connection-secret
+    namespace: default

--- a/examples/namespaced/mssql/user-shared-login.yaml
+++ b/examples/namespaced/mssql/user-shared-login.yaml
@@ -1,0 +1,66 @@
+# Shared login across databases: one User per database sharing the same
+# external-name (login/user name), passwordSecretRef and loginDatabase: master.
+# CREATE LOGIN only runs when the login is absent, so the second User reuses it.
+# Omit "Delete" from managementPolicies so deleting one User does not drop the
+# shared login and break its sibling.
+apiVersion: mssql.sql.m.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: db1
+  namespace: default
+spec:
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default
+---
+apiVersion: mssql.sql.m.crossplane.io/v1alpha1
+kind: Database
+metadata:
+  name: db2
+  namespace: default
+spec:
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default
+---
+apiVersion: mssql.sql.m.crossplane.io/v1alpha1
+kind: User
+metadata:
+  name: shared-login-user-db1
+  namespace: default
+  annotations:
+    crossplane.io/external-name: shared-login-user
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default
+  forProvider:
+    database: db1
+    loginDatabase: master
+    passwordSecretRef:
+      name: shared-login-pw
+      key: password
+  writeConnectionSecretToRef:
+    name: shared-login-user-db1-connection-secret
+---
+apiVersion: mssql.sql.m.crossplane.io/v1alpha1
+kind: User
+metadata:
+  name: shared-login-user-db2
+  namespace: default
+  annotations:
+    crossplane.io/external-name: shared-login-user
+spec:
+  managementPolicies: ["Observe", "Create", "Update", "LateInitialize"]
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default
+  forProvider:
+    database: db2
+    loginDatabase: master
+    passwordSecretRef:
+      name: shared-login-pw
+      key: password
+  writeConnectionSecretToRef:
+    name: shared-login-user-db2-connection-secret

--- a/pkg/controller/cluster/mssql/user/reconciler.go
+++ b/pkg/controller/cluster/mssql/user/reconciler.go
@@ -50,6 +50,7 @@ const (
 	errGetSecret    = "cannot get credentials Secret"
 
 	errSelectUser             = "cannot select user"
+	errSelectLogin            = "cannot select login %s"
 	errCreateUser             = "cannot create user %s"
 	errCreateLogin            = "cannot create login %s"
 	errDropUser               = "error dropping user %s"
@@ -203,19 +204,8 @@ func (c *external) Create(ctx context.Context, mg *v1alpha1.User) (managed.Exter
 			return managed.ExternalCreation{}, errors.Wrapf(err, errCreateUser, meta.GetExternalName(mg))
 		}
 	} else {
-		// Create traditional LOGIN + USER approach
-		loginQuery := fmt.Sprintf("CREATE LOGIN %s WITH PASSWORD=%s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteValue(pw))
-		if err := c.loginDB.Exec(ctx, xsql.Query{
-			String: loginQuery,
-		}); err != nil {
-			return managed.ExternalCreation{}, errors.Wrapf(err, errCreateLogin, meta.GetExternalName(mg))
-		}
-
-		userQuery := fmt.Sprintf("CREATE USER %s FOR LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteIdentifier(meta.GetExternalName(mg)))
-		if err := c.userDB.Exec(ctx, xsql.Query{
-			String: userQuery,
-		}); err != nil {
-			return managed.ExternalCreation{}, errors.Wrapf(err, errCreateUser, meta.GetExternalName(mg))
+		if err := c.createLoginAndUser(ctx, mg, pw); err != nil {
+			return managed.ExternalCreation{}, err
 		}
 	}
 
@@ -260,6 +250,50 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
+// createLoginAndUser creates the traditional server-level LOGIN plus the
+// database USER mapped to it. The LOGIN is a server-level object shared by all
+// databases, so a single login can back USERs in multiple databases. It is
+// only created when it does not already exist, so a second User for the same
+// login (in a different database) does not fail with "server principal already
+// exists" and retries after a partial failure are idempotent.
+func (c *external) createLoginAndUser(ctx context.Context, mg *v1alpha1.User, pw string) error {
+	exists, err := c.loginExists(ctx, meta.GetExternalName(mg))
+	if err != nil {
+		return errors.Wrapf(err, errSelectLogin, meta.GetExternalName(mg))
+	}
+	if !exists {
+		loginQuery := fmt.Sprintf("CREATE LOGIN %s WITH PASSWORD=%s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteValue(pw))
+		if err := c.loginDB.Exec(ctx, xsql.Query{
+			String: loginQuery,
+		}); err != nil {
+			return errors.Wrapf(err, errCreateLogin, meta.GetExternalName(mg))
+		}
+	}
+
+	userQuery := fmt.Sprintf("CREATE USER %s FOR LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteIdentifier(meta.GetExternalName(mg)))
+	if err := c.userDB.Exec(ctx, xsql.Query{
+		String: userQuery,
+	}); err != nil {
+		return errors.Wrapf(err, errCreateUser, meta.GetExternalName(mg))
+	}
+	return nil
+}
+
+// loginExists reports whether a server-level SQL login with the given name
+// already exists, queried against loginDB (the login database, normally
+// master). It lets Create and Delete treat the shared login idempotently.
+func (c *external) loginExists(ctx context.Context, name string) (bool, error) {
+	var got string
+	err := c.loginDB.Scan(ctx, xsql.Query{
+		String:     "SELECT name FROM sys.sql_logins WHERE name = @p1",
+		Parameters: []interface{}{name},
+	}, &got)
+	if xsql.IsNoRows(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 func (c *external) killLoginSessions(ctx context.Context, loginName string) error {
 	query := fmt.Sprintf("SELECT session_id FROM sys.dm_exec_sessions WHERE login_name = %s", mssql.QuoteValue(loginName))
 	rows, err := c.userDB.Query(ctx, xsql.Query{String: query})
@@ -296,12 +330,20 @@ func (c *external) Delete(ctx context.Context, mg *v1alpha1.User) (managed.Exter
 		return managed.ExternalDelete{}, errors.Wrapf(err, errDropUser, meta.GetExternalName(mg))
 	}
 
-	// Only drop LOGIN if this is not a contained user
+	// Only drop LOGIN if this is not a contained user, and only when it still
+	// exists. A shared login may already have been dropped by a sibling User
+	// (or orphaned on purpose), so guard the DROP to keep Delete idempotent.
 	if !isContained {
-		if err := c.loginDB.Exec(ctx, xsql.Query{
-			String: fmt.Sprintf("DROP LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg))),
-		}); err != nil {
-			return managed.ExternalDelete{}, errors.Wrapf(err, errDropLogin, meta.GetExternalName(mg))
+		exists, err := c.loginExists(ctx, meta.GetExternalName(mg))
+		if err != nil {
+			return managed.ExternalDelete{}, errors.Wrapf(err, errSelectLogin, meta.GetExternalName(mg))
+		}
+		if exists {
+			if err := c.loginDB.Exec(ctx, xsql.Query{
+				String: fmt.Sprintf("DROP LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg))),
+			}); err != nil {
+				return managed.ExternalDelete{}, errors.Wrapf(err, errDropLogin, meta.GetExternalName(mg))
+			}
 		}
 	}
 

--- a/pkg/controller/cluster/mssql/user/reconciler_test.go
+++ b/pkg/controller/cluster/mssql/user/reconciler_test.go
@@ -19,6 +19,7 @@ package user
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -460,6 +461,7 @@ func TestCreate(t *testing.T) {
 			reason: "Any errors encountered while creating the user should be returned",
 			fields: fields{
 				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
 					MockExec: func(ctx context.Context, q xsql.Query) error { return errBoom },
 				},
 			},
@@ -470,11 +472,63 @@ func TestCreate(t *testing.T) {
 				err: errors.Wrapf(errBoom, errCreateLogin, ""),
 			},
 		},
+		"SelectLoginError": {
+			reason: "Errors selecting the existing login should be returned",
+			fields: fields{
+				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return errBoom },
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{},
+			},
+			want: want{
+				err: errors.Wrapf(errBoom, errSelectLogin, ""),
+			},
+		},
 		"Success": {
 			reason: "No error should be returned when we successfully create a user",
 			fields: fields{
 				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
 					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							meta.AnnotationKeyExternalName: "example",
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				c: managed.ExternalCreation{
+					ConnectionDetails: managed.ConnectionDetails{
+						xpv1.ResourceCredentialsSecretUserKey:     []byte("example"),
+						xpv1.ResourceCredentialsSecretPasswordKey: []byte(""),
+						xpv1.ResourceCredentialsSecretEndpointKey: []byte("localhost"),
+						xpv1.ResourceCredentialsSecretPortKey:     []byte("3306"),
+					},
+				},
+			},
+		},
+		"LoginExists": {
+			reason: "When the login already exists we should skip CREATE LOGIN and only run CREATE USER FOR LOGIN",
+			fields: fields{
+				db: &mockDB{
+					// Login already exists: Scan returns no error.
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return nil },
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						// Fail if CREATE LOGIN is attempted for an existing login.
+						if strings.HasPrefix(q.String, "CREATE LOGIN") {
+							return errBoom
+						}
+						return nil
+					},
 				},
 			},
 			args: args{
@@ -503,6 +557,7 @@ func TestCreate(t *testing.T) {
 			comparePw: true,
 			fields: fields{
 				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
 					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
 				},
 				kube: &test.MockClient{
@@ -819,8 +874,8 @@ func TestDelete(t *testing.T) {
 			},
 			want: errors.Wrapf(errBoom, errDropUser, ""),
 		},
-		"Success": {
-			reason: "No error should be returned",
+		"SuccessLoginPresent": {
+			reason: "When the login still exists we should drop the user and the login",
 			fields: fields{
 				userDB: &mockDB{
 					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
@@ -831,7 +886,8 @@ func TestDelete(t *testing.T) {
 					},
 				},
 				loginDB: &mockDB{
-
+					// Login present: Scan returns no error.
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return nil },
 					MockExec: func(ctx context.Context, q xsql.Query) error {
 						return nil
 					},
@@ -840,6 +896,50 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.User{},
 			},
+		},
+		"SuccessLoginAbsent": {
+			reason: "When the login was already dropped we should drop the user but not attempt to drop the login",
+			fields: fields{
+				userDB: &mockDB{
+					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
+						return mockRowsToSQLRows(sqlmock.NewRows([]string{})), nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return nil
+					},
+				},
+				loginDB: &mockDB{
+					// Login absent: Scan returns no rows.
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
+					// Fail if DROP LOGIN is attempted for a missing login.
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return errBoom
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{},
+			},
+		},
+		"SelectLoginError": {
+			reason: "Errors selecting the existing login should be returned",
+			fields: fields{
+				userDB: &mockDB{
+					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
+						return mockRowsToSQLRows(sqlmock.NewRows([]string{})), nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return nil
+					},
+				},
+				loginDB: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return errBoom },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{},
+			},
+			want: errors.Wrapf(errBoom, errSelectLogin, ""),
 		},
 	}
 

--- a/pkg/controller/namespaced/mssql/user/reconciler.go
+++ b/pkg/controller/namespaced/mssql/user/reconciler.go
@@ -46,6 +46,7 @@ const (
 	errTrackPCUsage = "cannot track ProviderConfig usage"
 
 	errSelectUser             = "cannot select user"
+	errSelectLogin            = "cannot select login %s"
 	errCreateUser             = "cannot create user %s"
 	errCreateLogin            = "cannot create login %s"
 	errDropUser               = "error dropping user %s"
@@ -186,19 +187,8 @@ func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.User) (man
 			return managed.ExternalCreation{}, errors.Wrapf(err, errCreateUser, meta.GetExternalName(mg))
 		}
 	} else {
-		// Create traditional LOGIN + USER approach
-		loginQuery := fmt.Sprintf("CREATE LOGIN %s WITH PASSWORD=%s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteValue(pw))
-		if err := c.loginDB.Exec(ctx, xsql.Query{
-			String: loginQuery,
-		}); err != nil {
-			return managed.ExternalCreation{}, errors.Wrapf(err, errCreateLogin, meta.GetExternalName(mg))
-		}
-
-		userQuery := fmt.Sprintf("CREATE USER %s FOR LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteIdentifier(meta.GetExternalName(mg)))
-		if err := c.userDB.Exec(ctx, xsql.Query{
-			String: userQuery,
-		}); err != nil {
-			return managed.ExternalCreation{}, errors.Wrapf(err, errCreateUser, meta.GetExternalName(mg))
+		if err := c.createLoginAndUser(ctx, mg, pw); err != nil {
+			return managed.ExternalCreation{}, err
 		}
 	}
 
@@ -244,6 +234,50 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
+// createLoginAndUser creates the traditional server-level LOGIN plus the
+// database USER mapped to it. The LOGIN is a server-level object shared by all
+// databases, so a single login can back USERs in multiple databases. It is
+// only created when it does not already exist, so a second User for the same
+// login (in a different database) does not fail with "server principal already
+// exists" and retries after a partial failure are idempotent.
+func (c *external) createLoginAndUser(ctx context.Context, mg *namespacedv1alpha1.User, pw string) error {
+	exists, err := c.loginExists(ctx, meta.GetExternalName(mg))
+	if err != nil {
+		return errors.Wrapf(err, errSelectLogin, meta.GetExternalName(mg))
+	}
+	if !exists {
+		loginQuery := fmt.Sprintf("CREATE LOGIN %s WITH PASSWORD=%s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteValue(pw))
+		if err := c.loginDB.Exec(ctx, xsql.Query{
+			String: loginQuery,
+		}); err != nil {
+			return errors.Wrapf(err, errCreateLogin, meta.GetExternalName(mg))
+		}
+	}
+
+	userQuery := fmt.Sprintf("CREATE USER %s FOR LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg)), mssql.QuoteIdentifier(meta.GetExternalName(mg)))
+	if err := c.userDB.Exec(ctx, xsql.Query{
+		String: userQuery,
+	}); err != nil {
+		return errors.Wrapf(err, errCreateUser, meta.GetExternalName(mg))
+	}
+	return nil
+}
+
+// loginExists reports whether a server-level SQL login with the given name
+// already exists, queried against loginDB (the login database, normally
+// master). It lets Create and Delete treat the shared login idempotently.
+func (c *external) loginExists(ctx context.Context, name string) (bool, error) {
+	var got string
+	err := c.loginDB.Scan(ctx, xsql.Query{
+		String:     "SELECT name FROM sys.sql_logins WHERE name = @p1",
+		Parameters: []interface{}{name},
+	}, &got)
+	if xsql.IsNoRows(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 func (c *external) killLoginSessions(ctx context.Context, loginName string) error {
 	query := fmt.Sprintf("SELECT session_id FROM sys.dm_exec_sessions WHERE login_name = %s", mssql.QuoteValue(loginName))
 	rows, err := c.userDB.Query(ctx, xsql.Query{String: query})
@@ -280,12 +314,20 @@ func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.User) (man
 		return managed.ExternalDelete{}, errors.Wrapf(err, errDropUser, meta.GetExternalName(mg))
 	}
 
-	// Only drop LOGIN if this is not a contained user
+	// Only drop LOGIN if this is not a contained user, and only when it still
+	// exists. A shared login may already have been dropped by a sibling User
+	// (or orphaned on purpose), so guard the DROP to keep Delete idempotent.
 	if !isContained {
-		if err := c.loginDB.Exec(ctx, xsql.Query{
-			String: fmt.Sprintf("DROP LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg))),
-		}); err != nil {
-			return managed.ExternalDelete{}, errors.Wrapf(err, errDropLogin, meta.GetExternalName(mg))
+		exists, err := c.loginExists(ctx, meta.GetExternalName(mg))
+		if err != nil {
+			return managed.ExternalDelete{}, errors.Wrapf(err, errSelectLogin, meta.GetExternalName(mg))
+		}
+		if exists {
+			if err := c.loginDB.Exec(ctx, xsql.Query{
+				String: fmt.Sprintf("DROP LOGIN %s", mssql.QuoteIdentifier(meta.GetExternalName(mg))),
+			}); err != nil {
+				return managed.ExternalDelete{}, errors.Wrapf(err, errDropLogin, meta.GetExternalName(mg))
+			}
 		}
 	}
 

--- a/pkg/controller/namespaced/mssql/user/reconciler_test.go
+++ b/pkg/controller/namespaced/mssql/user/reconciler_test.go
@@ -19,6 +19,7 @@ package user
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -534,6 +535,7 @@ func TestCreate(t *testing.T) {
 			reason: "Any errors encountered while creating the user should be returned",
 			fields: fields{
 				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
 					MockExec: func(ctx context.Context, q xsql.Query) error { return errBoom },
 				},
 			},
@@ -544,11 +546,63 @@ func TestCreate(t *testing.T) {
 				err: errors.Wrapf(errBoom, errCreateLogin, ""),
 			},
 		},
+		"SelectLoginError": {
+			reason: "Errors selecting the existing login should be returned",
+			fields: fields{
+				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return errBoom },
+					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{},
+			},
+			want: want{
+				err: errors.Wrapf(errBoom, errSelectLogin, ""),
+			},
+		},
 		"Success": {
 			reason: "No error should be returned when we successfully create a user",
 			fields: fields{
 				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
 					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							meta.AnnotationKeyExternalName: "example",
+						},
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				c: managed.ExternalCreation{
+					ConnectionDetails: managed.ConnectionDetails{
+						xpv1.ResourceCredentialsSecretUserKey:     []byte("example"),
+						xpv1.ResourceCredentialsSecretPasswordKey: []byte(""),
+						xpv1.ResourceCredentialsSecretEndpointKey: []byte("localhost"),
+						xpv1.ResourceCredentialsSecretPortKey:     []byte("3306"),
+					},
+				},
+			},
+		},
+		"LoginExists": {
+			reason: "When the login already exists we should skip CREATE LOGIN and only run CREATE USER FOR LOGIN",
+			fields: fields{
+				db: &mockDB{
+					// Login already exists: Scan returns no error.
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return nil },
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						// Fail if CREATE LOGIN is attempted for an existing login.
+						if strings.HasPrefix(q.String, "CREATE LOGIN") {
+							return errBoom
+						}
+						return nil
+					},
 				},
 			},
 			args: args{
@@ -577,6 +631,7 @@ func TestCreate(t *testing.T) {
 			comparePw: true,
 			fields: fields{
 				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
 					MockExec: func(ctx context.Context, q xsql.Query) error { return nil },
 				},
 				kube: &test.MockClient{
@@ -893,8 +948,8 @@ func TestDelete(t *testing.T) {
 			},
 			want: errors.Wrapf(errBoom, errDropUser, ""),
 		},
-		"Success": {
-			reason: "No error should be returned",
+		"SuccessLoginPresent": {
+			reason: "When the login still exists we should drop the user and the login",
 			fields: fields{
 				userDB: &mockDB{
 					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
@@ -905,7 +960,8 @@ func TestDelete(t *testing.T) {
 					},
 				},
 				loginDB: &mockDB{
-
+					// Login present: Scan returns no error.
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return nil },
 					MockExec: func(ctx context.Context, q xsql.Query) error {
 						return nil
 					},
@@ -914,6 +970,50 @@ func TestDelete(t *testing.T) {
 			args: args{
 				mg: &v1alpha1.User{},
 			},
+		},
+		"SuccessLoginAbsent": {
+			reason: "When the login was already dropped we should drop the user but not attempt to drop the login",
+			fields: fields{
+				userDB: &mockDB{
+					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
+						return mockRowsToSQLRows(sqlmock.NewRows([]string{})), nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return nil
+					},
+				},
+				loginDB: &mockDB{
+					// Login absent: Scan returns no rows.
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return sql.ErrNoRows },
+					// Fail if DROP LOGIN is attempted for a missing login.
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return errBoom
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{},
+			},
+		},
+		"SelectLoginError": {
+			reason: "Errors selecting the existing login should be returned",
+			fields: fields{
+				userDB: &mockDB{
+					MockQuery: func(ctx context.Context, q xsql.Query) (*sql.Rows, error) {
+						return mockRowsToSQLRows(sqlmock.NewRows([]string{})), nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						return nil
+					},
+				},
+				loginDB: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error { return errBoom },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.User{},
+			},
+			want: errors.Wrapf(errBoom, errSelectLogin, ""),
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes
The MSSQL `User` controller forced `CREATE LOGIN` on every `Create`, so a second `User` sharing a server-level login (in a different database) failed with "server principal already exists". This change makes login creation idempotent so one login can back USERs across multiple databases.

For traditional (non-contained) users, `Create` now runs `CREATE LOGIN` only when the login doesn't already exist, then `CREATE USER FOR LOGIN`. This also fixes the retry case where a login was created but `CREATE USER` failed. Delete guards `DROP LOGIN` behind the same existence check, so a sibling (or orphaned) login already being gone doesn't hard-fail.

This change has been created and tested with LLM assistance.

Fixes #288

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Ran e2e tests locally.

[contribution process]: https://git.io/fj2m9
