### PR TITLE
chore(build): codeql broken - sync versions to 4.37.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   schedule:
     interval: monthly
   commit-message:
-      prefix: "chore: "
+    prefix: "chore: "
   ignore: # Handled via the crossplane-runtime, this should ensure we don't run into compatibility issues
     - dependency-name: "github.com/crossplane/crossplane-tools"
     - dependency-name: "sigs.k8s.io/*"
@@ -20,6 +20,11 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "monthly"
+    interval: "monthly"
   commit-message:
-      prefix: "chore: "
+    prefix: "chore: "
+  open-pull-requests-limit: 10
+  groups:
+    codeql-action:
+      patterns:
+        - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,9 @@ jobs:
           submodules: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: go
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1


### PR DESCRIPTION
### Description of your changes

Fixes red master build after dependabot PR got the actions out of sync:

> Error: analyze post-action step failed: Loaded a configuration file for version '4.36.0', but running version '4.36.2'

https://github.com/crossplane-contrib/provider-sql/actions/runs/29651898659/job/88099556201

This is due to a combination of lack of grouping and a low PR limit (5)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

n/a

[contribution process]: https://git.io/fj2m9
