### PR TITLE
fix(mysql): add lock_wait_timeout to DSN to stop statement pile-up

### DIFF
--- a/docs/mysql-driver-context-cancellation.md
+++ b/docs/mysql-driver-context-cancellation.md
@@ -1,0 +1,144 @@
+# MySQL driver context cancellation does not stop server-side statements
+
+This document records a behavior of `github.com/go-sql-driver/mysql` that has
+operational consequences for provider-sql, why it caused a production incident
+(MySQL/Percona becoming unresponsive with many `ALTER USER` statements pending),
+and how the provider mitigates it.
+
+## TL;DR
+
+- When a Go `context` is cancelled (including on deadline), the MySQL driver
+  **closes the TCP socket but does not send `KILL QUERY`**. The statement keeps
+  running / waiting on the server.
+- This is **intentional, longstanding driver behavior** and is present in every
+  release up to and including the current latest, `v1.10.0`. **Upgrading the
+  driver does not fix it** — it is not a bug to be patched away.
+- Combined with MySQL's default `lock_wait_timeout` of `31536000` seconds
+  (1 year), a statement blocked on a metadata / ACL lock stays pending forever
+  even after the provider gives up, and every reconcile retry adds another one.
+  They accumulate until the server runs out of connections or its ACL subsystem
+  is wedged.
+- Mitigation: provider-sql now appends `lock_wait_timeout` (and a dial
+  `timeout`) to the MySQL DSN so blocked statements **fail fast server-side and
+  release**, instead of piling up. See `pkg/clients/mysql/mysql.go`.
+
+## The driver behavior (verified in v1.10.0)
+
+On query/exec the driver arms a watcher goroutine
+(`connection.go` `startWatcher`). When `ctx.Done()` fires it calls
+`mc.cancel(err)` → `mc.cleanup()`, and `cleanup()` simply does
+`close(mc.closech)` and `conn.Close()` on the raw network connection. There is
+no code path that opens a side connection and issues `KILL QUERY <id>`.
+
+From Go's point of view the query is cancelled and the call returns
+`context.DeadlineExceeded`. From MySQL's point of view the session's statement
+continues: for a statement blocked in `Waiting for metadata lock`, the server
+thread does **not** poll socket liveness during the lock wait, so it keeps
+waiting until it acquires the lock (then notices the dead client) or is killed
+out of band.
+
+The driver maintainers' recommended way to actually cancel server-side is the
+application's job: check out a dedicated connection, read its
+`CONNECTION_ID()`, and issue `KILL QUERY <id>` from a **separate** connection
+on cancel. provider-sql does not do this (see "What this does not cover").
+
+References:
+- <https://github.com/go-sql-driver/mysql/issues/863> — query keeps running after context cancel
+- <https://github.com/go-sql-driver/mysql/issues/925> — context cancellation semantics
+- <https://github.com/go-sql-driver/mysql/issues/1631> — DeadlineExceeded closes the network connection
+- <https://medium.com/@rocketlaunchr.cloud/canceling-mysql-in-go-827ed8f83b30> — the app-level `KILL QUERY` pattern
+
+## Why it caused an incident here
+
+1. **Every write goes through one path.** All MySQL controllers issue writes via
+   `mysql.ExecWrapper → c.db.Exec`, which opens a fresh connection per call
+   (`pkg/clients/mysql/mysql.go`). This covers, in the User controller,
+   `CREATE USER`, `ALTER USER ... WITH <connection limits/resource options>`,
+   `ALTER USER ... IDENTIFIED WITH <plugin>`, `ALTER USER ... IDENTIFIED BY`,
+   `DROP USER`; in Grant, `GRANT` / `REVOKE`; in Database,
+   `CREATE/ALTER/DROP DATABASE`. Password rotation is only the *most frequent*
+   trigger — any of these statements can block.
+
+2. **The reconcile deadline is 60s.** crossplane-runtime applies a default
+   `reconcileTimeout` of 1 minute (provider-sql does not override it via
+   `managed.WithTimeout`). So the provider goroutine is *not* hung forever — it
+   is cancelled at ~60s.
+
+3. **But cancellation only closes the socket (see above).** The abandoned
+   `ALTER USER` / `GRANT` keeps waiting on the server because of the 1-year
+   default `lock_wait_timeout`.
+
+4. **Retries re-issue the statement.** The 60s cancellation surfaces as an
+   error, crossplane requeues with backoff, and the next reconcile opens a new
+   connection and issues the statement again — which also blocks.
+
+5. **The ACL global lock amplifies it.** MySQL account-management statements
+   (`CREATE/ALTER/DROP USER`, `GRANT`, `REVOKE`) serialize on a single global
+   ACL lock. One stuck statement stalls *every* account-management statement
+   server-wide, not just ones touching the same object.
+
+6. **A feedback loop keeps it going.** Controllers persist observed state only
+   *after* a successful statement. While the statement keeps failing, observed
+   state never updates, so the next reconcile re-diffs and re-issues the same
+   blocked statement every poll cycle.
+
+Net effect: blocked statements and their connections accumulate until
+`max_connections` is exhausted and/or ACL contention wedges account management
+— the database appears unresponsive.
+
+A common real-world trigger for the initial block is a backup
+(e.g. Percona XtraBackup / `FLUSH TABLES WITH READ LOCK`) or a long-running
+transaction holding a lock that account-management DDL must wait behind.
+
+## Mitigation implemented
+
+`DSN()` in `pkg/clients/mysql/mysql.go` now appends:
+
+- `lock_wait_timeout=30` — an unrecognised driver parameter, so go-sql-driver
+  issues `SET lock_wait_timeout = 30` on connect. A statement that cannot get
+  its metadata / ACL lock within 30s **fails server-side and releases** instead
+  of waiting up to a year. The provider then retries on the normal reconcile
+  backoff once the lock clears.
+- `timeout=10s` — the driver's dial timeout, so a reconcile does not block on
+  an unreachable endpoint.
+
+This directly breaks the pile-up chain for the lock-wait case that caused the
+incident, and it applies to every MySQL controller (User, Grant, Database, both
+cluster- and namespaced-scoped) because they all share this client.
+
+## What this does *not* cover
+
+`lock_wait_timeout` only bounds waits for metadata / ACL locks. A statement
+hung for a *non-lock* reason — a dead network path, or a server wedged
+mid-execution — is still only socket-closed-without-`KILL` at the 60s reconcile
+deadline, and can continue running server-side. The only remedy for that class
+is the application-level `KILL QUERY` pattern described above.
+
+## Recommended follow-ups (not in this change)
+
+- **Application-level `KILL QUERY` on cancel** for the non-lock hang case
+  (dedicated connection + `CONNECTION_ID()` + out-of-band `KILL`).
+- **Bounded shared connection pool.** The client currently calls `sql.Open` per
+  query and closes it immediately (no reuse, no `SetMaxOpenConns` /
+  `SetConnMaxLifetime`). A shared, capped `*sql.DB` would hard-limit total
+  connections and remove per-query connect/auth overhead, but requires adding a
+  `Close()` to the `xsql.DB` interface and wiring it through `Disconnect` for
+  all three drivers (MySQL, PostgreSQL, MSSQL).
+- **Harden the reconcile feedback loop** so a persistently failing statement
+  does not re-fire every poll cycle.
+- **Make `lock_wait_timeout` configurable** (e.g. via `ProviderConfig`) for
+  environments that legitimately need longer or shorter waits.
+
+## Reproducing / verifying
+
+1. Create a MySQL `User` with a `PasswordSecretRef`.
+2. In a separate MySQL session, hold a lock the DDL must wait behind
+   (e.g. `LOCK TABLES mysql.user WRITE`, or an open transaction).
+3. Rotate the password so the provider issues `ALTER USER ... IDENTIFIED BY`.
+
+- **Before the fix:** `SHOW PROCESSLIST` accumulates
+  `ALTER USER ... | Waiting for metadata lock` threads and the connection count
+  climbs with every reconcile.
+- **After the fix:** the `ALTER USER` fails with a lock-wait-timeout error
+  within ~30s and is retried on backoff; `SHOW PROCESSLIST` stays clean and the
+  connection count stays flat.

--- a/docs/mysql-driver-context-cancellation.md
+++ b/docs/mysql-driver-context-cancellation.md
@@ -51,8 +51,9 @@ References:
 ## Why it caused an incident here
 
 1. **Every write goes through one path.** All MySQL controllers issue writes via
-   `mysql.ExecWrapper → c.db.Exec`, which opens a fresh connection per call
-   (`pkg/clients/mysql/mysql.go`). This covers, in the User controller,
+   `mysql.ExecWrapper → c.db.Exec`. At the time of the incident this opened a
+   fresh connection per call (`pkg/clients/mysql/mysql.go`); see the connection
+   pool follow-up below. This covers, in the User controller,
    `CREATE USER`, `ALTER USER ... WITH <connection limits/resource options>`,
    `ALTER USER ... IDENTIFIED WITH <plugin>`, `ALTER USER ... IDENTIFIED BY`,
    `DROP USER`; in Grant, `GRANT` / `REVOKE`; in Database,
@@ -118,12 +119,11 @@ is the application-level `KILL QUERY` pattern described above.
 
 - **Application-level `KILL QUERY` on cancel** for the non-lock hang case
   (dedicated connection + `CONNECTION_ID()` + out-of-band `KILL`).
-- **Bounded shared connection pool.** The client currently calls `sql.Open` per
-  query and closes it immediately (no reuse, no `SetMaxOpenConns` /
-  `SetConnMaxLifetime`). A shared, capped `*sql.DB` would hard-limit total
-  connections and remove per-query connect/auth overhead, but requires adding a
-  `Close()` to the `xsql.DB` interface and wiring it through `Disconnect` for
-  all three drivers (MySQL, PostgreSQL, MSSQL).
+- **Bounded shared connection pool.** Addressed separately — see
+  `docs/connection-pool.md` and #195/#434, which introduce a shared, DSN-keyed
+  `*sql.DB` pool (with `MaxOpenConns` / `MaxIdleConns` / `ConnMaxLifetime` /
+  `ConnMaxIdleTime`) across all three drivers instead of opening a new
+  connection per query.
 - **Harden the reconcile feedback loop** so a persistently failing statement
   does not re-fire every poll cycle.
 - **Make `lock_wait_timeout` configurable** (e.g. via `ProviderConfig`) for

--- a/pkg/clients/mysql/mysql.go
+++ b/pkg/clients/mysql/mysql.go
@@ -17,21 +17,7 @@ import (
 const (
 	errNotSupported = "%s not supported by mysql client"
 
-	// lockWaitTimeoutSeconds bounds how long a statement waits for a metadata
-	// lock before failing server-side. MySQL's default lock_wait_timeout is
-	// 31536000s (1 year), so a statement queued behind a lock — e.g. an
-	// ALTER USER / GRANT / DROP DATABASE waiting behind a backup, a long
-	// transaction, or concurrent DDL — stays pending on the server
-	// effectively forever. This is dangerous here because the go-sql-driver
-	// cancels a context by closing the TCP socket WITHOUT issuing KILL, so
-	// when the reconcile deadline fires the provider abandons the statement
-	// but the server thread (and its connection) keeps waiting. Every retry
-	// then issues another statement that also blocks, and account-management
-	// statements additionally serialize on a single global ACL lock, so
-	// blocked statements pile up until the server becomes unresponsive. A
-	// short lock_wait_timeout makes such statements fail fast and release
-	// instead of accumulating.
-	//
+	// prevent statements hanging indefintely server-side if timeout occurs waiting for a lock
 	// See docs/mysql-driver-context-cancellation.md for the full analysis.
 	lockWaitTimeoutSeconds = 30
 	// dialTimeout bounds TCP connection establishment so a reconcile does not
@@ -68,16 +54,7 @@ func New(creds map[string][]byte, tls *string, binlog *bool) xsql.DB {
 
 // DSN returns the DSN URL
 func DSN(username, password, endpoint, port, tls string, binlog *bool) string {
-	// Use net/url UserPassword to encode the username and password
-	// This will ensure that any special characters in the username or password
-	// are percent-encoded for use in the user info portion of the DSN URL
-
-	// lock_wait_timeout and timeout are appended to every connection so that a
-	// statement blocked on a metadata lock, or a connection to an unreachable
-	// endpoint, fails fast server-side instead of piling up (see the const
-	// docs above). lock_wait_timeout is an unrecognised driver param and is
-	// therefore issued as `SET lock_wait_timeout = <n>` by go-sql-driver on
-	// connect; timeout is the driver's dial timeout.
+	// add timeouts to prevent orphaned statements and excessive waits on connection dial
 	params := fmt.Sprintf("tls=%s&lock_wait_timeout=%d&timeout=%s",
 		tls,
 		lockWaitTimeoutSeconds,

--- a/pkg/clients/mysql/mysql.go
+++ b/pkg/clients/mysql/mysql.go
@@ -16,6 +16,27 @@ import (
 
 const (
 	errNotSupported = "%s not supported by mysql client"
+
+	// lockWaitTimeoutSeconds bounds how long a statement waits for a metadata
+	// lock before failing server-side. MySQL's default lock_wait_timeout is
+	// 31536000s (1 year), so a statement queued behind a lock — e.g. an
+	// ALTER USER / GRANT / DROP DATABASE waiting behind a backup, a long
+	// transaction, or concurrent DDL — stays pending on the server
+	// effectively forever. This is dangerous here because the go-sql-driver
+	// cancels a context by closing the TCP socket WITHOUT issuing KILL, so
+	// when the reconcile deadline fires the provider abandons the statement
+	// but the server thread (and its connection) keeps waiting. Every retry
+	// then issues another statement that also blocks, and account-management
+	// statements additionally serialize on a single global ACL lock, so
+	// blocked statements pile up until the server becomes unresponsive. A
+	// short lock_wait_timeout makes such statements fail fast and release
+	// instead of accumulating.
+	//
+	// See docs/mysql-driver-context-cancellation.md for the full analysis.
+	lockWaitTimeoutSeconds = 30
+	// dialTimeout bounds TCP connection establishment so a reconcile does not
+	// block on an unreachable endpoint.
+	dialTimeout = "10s"
 )
 
 type mySQLDB struct {
@@ -50,21 +71,27 @@ func DSN(username, password, endpoint, port, tls string, binlog *bool) string {
 	// Use net/url UserPassword to encode the username and password
 	// This will ensure that any special characters in the username or password
 	// are percent-encoded for use in the user info portion of the DSN URL
+
+	// lock_wait_timeout and timeout are appended to every connection so that a
+	// statement blocked on a metadata lock, or a connection to an unreachable
+	// endpoint, fails fast server-side instead of piling up (see the const
+	// docs above). lock_wait_timeout is an unrecognised driver param and is
+	// therefore issued as `SET lock_wait_timeout = <n>` by go-sql-driver on
+	// connect; timeout is the driver's dial timeout.
+	params := fmt.Sprintf("tls=%s&lock_wait_timeout=%d&timeout=%s",
+		tls,
+		lockWaitTimeoutSeconds,
+		dialTimeout,
+	)
 	if binlog != nil {
-		return fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&sql_log_bin=%s",
-			username,
-			password,
-			endpoint,
-			port,
-			tls,
-			strconv.FormatBool(*binlog))
+		params += fmt.Sprintf("&sql_log_bin=%s", strconv.FormatBool(*binlog))
 	}
-	return fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/?%s",
 		username,
 		password,
 		endpoint,
 		port,
-		tls)
+		params)
 }
 
 // ExecTx is unsupported in MySQL.

--- a/pkg/clients/mysql/mysql_test.go
+++ b/pkg/clients/mysql/mysql_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
 )
 
 func TestDSNURLEscaping(t *testing.T) {
@@ -14,12 +16,14 @@ func TestDSNURLEscaping(t *testing.T) {
 	tls := "true"
 	binlog := false
 	dsn := DSN(user, rawPass, endpoint, port, tls, &binlog)
-	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&sql_log_bin=%s",
+	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&lock_wait_timeout=%d&timeout=%s&sql_log_bin=%s",
 		user,
 		rawPass,
 		endpoint,
 		port,
 		tls,
+		lockWaitTimeoutSeconds,
+		dialTimeout,
 		strconv.FormatBool(binlog)) {
 		t.Errorf("DSN string did not match expected output with URL encoded and binlog")
 	}
@@ -32,12 +36,35 @@ func TestDSNURLEscapingWithoutBinLog(t *testing.T) {
 	rawPass := "password^"
 	tls := "true"
 	dsn := DSN(user, rawPass, endpoint, port, tls, nil)
-	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s",
+	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&lock_wait_timeout=%d&timeout=%s",
 		user,
 		rawPass,
 		endpoint,
 		port,
-		tls) {
+		tls,
+		lockWaitTimeoutSeconds,
+		dialTimeout) {
 		t.Errorf("DSN string did not match expected output with URL encoded")
+	}
+}
+
+// TestDSNParsesWithLockWaitTimeout guards against a typo in the DSN param
+// names: it verifies the go-sql-driver actually parses the DSN we build and
+// that lock_wait_timeout is carried as a session variable (issued as
+// `SET lock_wait_timeout = <n>` on connect) and timeout as the dial timeout.
+func TestDSNParsesWithLockWaitTimeout(t *testing.T) {
+	dsn := DSN("username", "password", "endpoint", "3306", "preferred", nil)
+
+	cfg, err := mysqldriver.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("go-sql-driver could not parse the DSN we build: %v", err)
+	}
+
+	want := strconv.Itoa(lockWaitTimeoutSeconds)
+	if got := cfg.Params["lock_wait_timeout"]; got != want {
+		t.Errorf("lock_wait_timeout: got %q, want %q", got, want)
+	}
+	if cfg.Timeout == 0 {
+		t.Errorf("dial timeout was not parsed from the DSN")
 	}
 }


### PR DESCRIPTION
### Description of your changes

Under a backlog of pending `ALTER USER`/`GRANT`/DDL statements, MySQL/Percona can become unresponsive. `go-sql-driver/mysql` cancels a context by closing the TCP socket **without** sending `KILL QUERY` (intentional; all versions incl. latest v1.10.0). With MySQL's default `lock_wait_timeout` of 1 year, a statement blocked on a metadata/ACL lock (e.g. behind a backup or long transaction) stays pending server-side even after the 60s reconcile deadline. Every retry adds another; account-management statements serialize on a single global ACL lock, so they pile up until `max_connections` is exhausted or the server wedges.

This PR appends `lock_wait_timeout=30` and dial `timeout=10s` to the MySQL DSN so blocked statements fail fast server-side and release instead of accumulating. Applies to all MySQL controllers (User, Grant, Database; cluster + namespaced) via the shared client.

Not covered / follow-ups:
- Non-lock hangs (dead network, server wedged mid-execution) still only get socket-closed-without-KILL; app-level `KILL QUERY` is the only remedy.
- Bounded shared connection pool — addressed separately, see #434.
- Making `lock_wait_timeout` configurable via `ProviderConfig`.

See `docs/mysql-driver-context-cancellation.md` for the full analysis.

Fixes #422

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Updated DSN assertions; added `TestDSNParsesWithLockWaitTimeout` validating the DSN parses via the driver and carries the params.
- `go build ./...`, `go vet`, and full MySQL controller test suites pass.
- `make` and `make reviewable` pass.

[contribution process]: https://git.io/fj2m9