### PR TITLE
Honour Extension schema on create and update

### DIFF
--- a/apis/cluster/postgresql/v1alpha1/extension_types.go
+++ b/apis/cluster/postgresql/v1alpha1/extension_types.go
@@ -32,7 +32,9 @@ type ExtensionParameters struct {
 	// +optional
 	Version *string `json:"version,omitempty"`
 
-	// Schema for extension install.
+	// Schema to install the extension into. It must already exist.
+	// Changing it moves the extension with ALTER EXTENSION ... SET SCHEMA,
+	// which non-relocatable extensions (e.g. postgis) reject.
 	// +optional
 	Schema *string `json:"schema,omitempty"`
 

--- a/apis/namespaced/postgresql/v1alpha1/extension_types.go
+++ b/apis/namespaced/postgresql/v1alpha1/extension_types.go
@@ -33,7 +33,9 @@ type ExtensionParameters struct {
 	// +optional
 	Version *string `json:"version,omitempty"`
 
-	// Schema for extension install.
+	// Schema to install the extension into. It must already exist.
+	// Changing it moves the extension with ALTER EXTENSION ... SET SCHEMA,
+	// which non-relocatable extensions (e.g. postgis) reject.
 	// +optional
 	Schema *string `json:"schema,omitempty"`
 

--- a/cluster/local/postgresdb_functions.sh
+++ b/cluster/local/postgresdb_functions.sh
@@ -450,6 +450,16 @@ check_extension_test() {
     echo_error "ERROR: Extensions not found in database. hstore: $hstore_installed, ltree: $ltree_installed"
   fi
 
+  # Verify the schema clause: ltree asks for my-schema, hstore defaults to public
+  echo_sub_step "Checking extension schemas"
+  ext_schemas=$(PGPASSWORD="${postgres_root_pw}" psql -h localhost -p 5432 -U postgres -d example -wtAc "SELECT e.extname || '=' || n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace WHERE e.extname IN ('hstore', 'ltree') ORDER BY 1;" | paste -sd ' ' -)
+
+  if [[ "$ext_schemas" == "hstore=public ltree=my-schema" ]]; then
+    echo_info "Extensions are installed in the expected schemas"
+  else
+    echo_error "ERROR: Unexpected extension schemas: $ext_schemas"
+  fi
+
   echo_step_completed
 }
 

--- a/examples/cluster/postgresql/extension.yaml
+++ b/examples/cluster/postgresql/extension.yaml
@@ -19,6 +19,7 @@ spec:
   forProvider:
     extension: ltree
     version: "1.1"
+    schema: my-schema
     databaseRef:
       name: example
   providerConfigRef:

--- a/examples/namespaced/postgresql/extension.yaml
+++ b/examples/namespaced/postgresql/extension.yaml
@@ -23,6 +23,7 @@ spec:
   forProvider:
     extension: ltree
     version: "1.1"
+    schema: my-schema
     databaseRef:
       name: example
       namespace: default  # Explicitly set namespace (demonstrates namespace scoping)

--- a/package/crds/postgresql.sql.crossplane.io_extensions.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_extensions.yaml
@@ -164,7 +164,10 @@ spec:
                     description: Extension name to be installed.
                     type: string
                   schema:
-                    description: Schema for extension install.
+                    description: |-
+                      Schema to install the extension into. It must already exist.
+                      Changing it moves the extension with ALTER EXTENSION ... SET SCHEMA,
+                      which non-relocatable extensions (e.g. postgis) reject.
                     type: string
                   version:
                     description: Version of the extension to be installed.

--- a/package/crds/postgresql.sql.m.crossplane.io_extensions.yaml
+++ b/package/crds/postgresql.sql.m.crossplane.io_extensions.yaml
@@ -156,7 +156,10 @@ spec:
                     description: Extension name to be installed.
                     type: string
                   schema:
-                    description: Schema for extension install.
+                    description: |-
+                      Schema to install the extension into. It must already exist.
+                      Changing it moves the extension with ALTER EXTENSION ... SET SCHEMA,
+                      which non-relocatable extensions (e.g. postgis) reject.
                     type: string
                   version:
                     description: Version of the extension to be installed.

--- a/pkg/controller/cluster/postgresql/extension/reconciler.go
+++ b/pkg/controller/cluster/postgresql/extension/reconciler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -50,6 +51,7 @@ const (
 
 	errSelectExtension = "cannot select extension"
 	errCreateExtension = "cannot create extension"
+	errAlterExtension  = "cannot alter extension"
 	errDropExtension   = "cannot drop extension"
 
 	maxConcurrency = 5
@@ -136,23 +138,32 @@ type external struct{ db xsql.DB }
 
 var _ managed.TypedExternalClient[*v1alpha1.Extension] = &external{}
 
-func (c *external) Observe(ctx context.Context, mg *v1alpha1.Extension) (managed.ExternalObservation, error) {
+// observe reads the installed version and schema of an extension.
+func (c *external) observe(ctx context.Context, name string) (v1alpha1.ExtensionParameters, error) {
 	// If the Extension exists, it will have all of these properties.
 	observed := v1alpha1.ExtensionParameters{
 		Version: new(string),
+		Schema:  new(string),
 	}
 
 	query := "SELECT " +
-		"extversion " +
-		"FROM pg_extension " +
-		"WHERE extname = $1"
+		"e.extversion, n.nspname " +
+		"FROM pg_extension e " +
+		"JOIN pg_namespace n ON n.oid = e.extnamespace " +
+		"WHERE e.extname = $1"
 
 	err := c.db.Scan(ctx, xsql.Query{
 		String:     query,
-		Parameters: []interface{}{mg.Spec.ForProvider.Extension},
+		Parameters: []interface{}{name},
 	},
 		observed.Version,
+		observed.Schema,
 	)
+	return observed, err
+}
+
+func (c *external) Observe(ctx context.Context, mg *v1alpha1.Extension) (managed.ExternalObservation, error) {
+	observed, err := c.observe(ctx, mg.Spec.ForProvider.Extension)
 
 	// If the database we try to connect on does not exist then
 	// there cannot be an extension on that database either.
@@ -165,9 +176,12 @@ func (c *external) Observe(ctx context.Context, mg *v1alpha1.Extension) (managed
 
 	mg.SetConditions(xpv1.Available())
 
+	// lateInit first: upToDate compares against the filled-in spec.
+	li := lateInit(observed, &mg.Spec.ForProvider)
+
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceLateInitialized: lateInit(observed, &mg.Spec.ForProvider),
+		ResourceLateInitialized: li,
 		ResourceUpToDate:        upToDate(observed, mg.Spec.ForProvider),
 	}, nil
 }
@@ -182,11 +196,36 @@ func (c *external) Create(ctx context.Context, mg *v1alpha1.Extension) (managed.
 		b.WriteString(pq.QuoteIdentifier(*mg.Spec.ForProvider.Version))
 	}
 
+	if mg.Spec.ForProvider.Schema != nil {
+		b.WriteString(" SCHEMA ")
+		b.WriteString(pq.QuoteIdentifier(*mg.Spec.ForProvider.Schema))
+	}
+
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: b.String()}), errCreateExtension)
 }
 
-func (c *external) Update(_ context.Context, mg *v1alpha1.Extension) (managed.ExternalUpdate, error) { //nolint:gocyclo
-	return managed.ExternalUpdate{}, nil
+func (c *external) Update(ctx context.Context, mg *v1alpha1.Extension) (managed.ExternalUpdate, error) {
+	desired := mg.Spec.ForProvider
+	if desired.Schema == nil {
+		return managed.ExternalUpdate{}, nil
+	}
+
+	// Update gets no observation; re-read so a version-only
+	// mismatch issues no statement.
+	observed, err := c.observe(ctx, desired.Extension)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errSelectExtension)
+	}
+	if *observed.Schema == *desired.Schema {
+		return managed.ExternalUpdate{}, nil
+	}
+
+	// Non-relocatable extensions (e.g. postgis) reject this; the
+	// engine's error is surfaced as-is.
+	query := "ALTER EXTENSION " + pq.QuoteIdentifier(desired.Extension) +
+		" SET SCHEMA " + pq.QuoteIdentifier(*desired.Schema)
+	err = c.db.Exec(ctx, xsql.Query{String: query})
+	return managed.ExternalUpdate{}, errors.Wrap(err, errAlterExtension)
 }
 
 func (c *external) Disconnect(ctx context.Context) error {
@@ -198,11 +237,9 @@ func (c *external) Delete(ctx context.Context, mg *v1alpha1.Extension) (managed.
 	return managed.ExternalDelete{}, errors.Wrap(err, errDropExtension)
 }
 
+// upToDate runs after lateInit, so desired is set wherever observed is.
 func upToDate(observed, desired v1alpha1.ExtensionParameters) bool {
-	if desired.Version == nil || (observed.Version != nil && *desired.Version == *observed.Version) {
-		return true
-	}
-	return false
+	return ptr.Equal(observed.Version, desired.Version) && ptr.Equal(observed.Schema, desired.Schema)
 }
 
 func lateInit(observed v1alpha1.ExtensionParameters, desired *v1alpha1.ExtensionParameters) bool {
@@ -210,6 +247,11 @@ func lateInit(observed v1alpha1.ExtensionParameters, desired *v1alpha1.Extension
 
 	if desired.Version == nil && observed.Version != nil {
 		desired.Version = observed.Version
+		li = true
+	}
+
+	if desired.Schema == nil && observed.Schema != nil {
+		desired.Schema = observed.Schema
 		li = true
 	}
 

--- a/pkg/controller/cluster/postgresql/extension/reconciler_test.go
+++ b/pkg/controller/cluster/postgresql/extension/reconciler_test.go
@@ -247,6 +247,7 @@ func TestObserve(t *testing.T) {
 					Spec: v1alpha1.ExtensionSpec{
 						ForProvider: v1alpha1.ExtensionParameters{
 							Version: new(string),
+							Schema:  new(string),
 						},
 					},
 				},
@@ -283,6 +284,33 @@ func TestObserve(t *testing.T) {
 					ResourceExists:          true,
 					ResourceUpToDate:        true,
 					ResourceLateInitialized: true,
+				},
+			},
+		},
+		"SchemaMismatch": {
+			reason: "Installed in another schema than desired: not up to date",
+			fields: fields{
+				db: mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*dest[0].(*string) = "1.8"
+						*dest[1].(*string) = "public"
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Version: new("1.8"),
+							Schema:  new("gis"),
+						},
+					},
+				},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists: true,
 				},
 			},
 		},
@@ -359,6 +387,30 @@ func TestCreate(t *testing.T) {
 				err: nil,
 			},
 		},
+		"WithSchema": {
+			reason: "Schema is appended, quoted, after the version",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						if q.String != `CREATE EXTENSION IF NOT EXISTS "postgis" WITH VERSION "3.6.0" SCHEMA "Mixed Case"` {
+							return errors.New(q.String)
+						}
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Extension: "postgis",
+							Version:   new("3.6.0"),
+							Schema:    new("Mixed Case"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -376,6 +428,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	errBoom := errors.New("boom")
+
 	type fields struct {
 		db xsql.DB
 	}
@@ -414,6 +468,58 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				err: nil,
+			},
+		},
+		"SchemaUnchanged": {
+			reason: "No statement when the extension already is in the desired schema",
+			fields: fields{
+				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*dest[1].(*string) = "gis"
+						return nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error { return errors.New(q.String) },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Extension: "hstore",
+							Schema:    new("gis"),
+						},
+					},
+				},
+			},
+		},
+		"SchemaMoved": {
+			reason: "A differing schema is fixed with ALTER EXTENSION ... SET SCHEMA; its error is wrapped",
+			fields: fields{
+				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*dest[1].(*string) = "public"
+						return nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						if q.String != `ALTER EXTENSION "hstore" SET SCHEMA "gis"` {
+							return errors.New(q.String)
+						}
+						return errBoom
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Extension: "hstore",
+							Schema:    new("gis"),
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errAlterExtension),
 			},
 		},
 	}

--- a/pkg/controller/namespaced/postgresql/extension/reconciler.go
+++ b/pkg/controller/namespaced/postgresql/extension/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -46,6 +47,7 @@ const (
 
 	errSelectExtension = "cannot select extension"
 	errCreateExtension = "cannot create extension"
+	errAlterExtension  = "cannot alter extension"
 	errDropExtension   = "cannot drop extension"
 
 	maxConcurrency = 5
@@ -118,23 +120,32 @@ type external struct{ db xsql.DB }
 
 var _ managed.TypedExternalClient[*namespacedv1alpha1.Extension] = &external{}
 
-func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Extension) (managed.ExternalObservation, error) {
+// observe reads the installed version and schema of an extension.
+func (c *external) observe(ctx context.Context, name string) (namespacedv1alpha1.ExtensionParameters, error) {
 	// If the Extension exists, it will have all of these properties.
 	observed := namespacedv1alpha1.ExtensionParameters{
 		Version: new(string),
+		Schema:  new(string),
 	}
 
 	query := "SELECT " +
-		"extversion " +
-		"FROM pg_extension " +
-		"WHERE extname = $1"
+		"e.extversion, n.nspname " +
+		"FROM pg_extension e " +
+		"JOIN pg_namespace n ON n.oid = e.extnamespace " +
+		"WHERE e.extname = $1"
 
 	err := c.db.Scan(ctx, xsql.Query{
 		String:     query,
-		Parameters: []interface{}{mg.Spec.ForProvider.Extension},
+		Parameters: []interface{}{name},
 	},
 		observed.Version,
+		observed.Schema,
 	)
+	return observed, err
+}
+
+func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Extension) (managed.ExternalObservation, error) {
+	observed, err := c.observe(ctx, mg.Spec.ForProvider.Extension)
 
 	// If the database we try to connect on does not exist then
 	// there cannot be an extension on that database either.
@@ -147,9 +158,12 @@ func (c *external) Observe(ctx context.Context, mg *namespacedv1alpha1.Extension
 
 	mg.SetConditions(xpv1.Available())
 
+	// lateInit first: upToDate compares against the filled-in spec.
+	li := lateInit(observed, &mg.Spec.ForProvider)
+
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceLateInitialized: lateInit(observed, &mg.Spec.ForProvider),
+		ResourceLateInitialized: li,
 		ResourceUpToDate:        upToDate(observed, mg.Spec.ForProvider),
 	}, nil
 }
@@ -164,11 +178,36 @@ func (c *external) Create(ctx context.Context, mg *namespacedv1alpha1.Extension)
 		b.WriteString(pq.QuoteIdentifier(*mg.Spec.ForProvider.Version))
 	}
 
+	if mg.Spec.ForProvider.Schema != nil {
+		b.WriteString(" SCHEMA ")
+		b.WriteString(pq.QuoteIdentifier(*mg.Spec.ForProvider.Schema))
+	}
+
 	return managed.ExternalCreation{}, errors.Wrap(c.db.Exec(ctx, xsql.Query{String: b.String()}), errCreateExtension)
 }
 
-func (c *external) Update(_ context.Context, mg *namespacedv1alpha1.Extension) (managed.ExternalUpdate, error) { //nolint:gocyclo
-	return managed.ExternalUpdate{}, nil
+func (c *external) Update(ctx context.Context, mg *namespacedv1alpha1.Extension) (managed.ExternalUpdate, error) {
+	desired := mg.Spec.ForProvider
+	if desired.Schema == nil {
+		return managed.ExternalUpdate{}, nil
+	}
+
+	// Update gets no observation; re-read so a version-only
+	// mismatch issues no statement.
+	observed, err := c.observe(ctx, desired.Extension)
+	if err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errSelectExtension)
+	}
+	if *observed.Schema == *desired.Schema {
+		return managed.ExternalUpdate{}, nil
+	}
+
+	// Non-relocatable extensions (e.g. postgis) reject this; the
+	// engine's error is surfaced as-is.
+	query := "ALTER EXTENSION " + pq.QuoteIdentifier(desired.Extension) +
+		" SET SCHEMA " + pq.QuoteIdentifier(*desired.Schema)
+	err = c.db.Exec(ctx, xsql.Query{String: query})
+	return managed.ExternalUpdate{}, errors.Wrap(err, errAlterExtension)
 }
 
 func (c *external) Disconnect(ctx context.Context) error {
@@ -180,11 +219,9 @@ func (c *external) Delete(ctx context.Context, mg *namespacedv1alpha1.Extension)
 	return managed.ExternalDelete{}, errors.Wrap(err, errDropExtension)
 }
 
+// upToDate runs after lateInit, so desired is set wherever observed is.
 func upToDate(observed, desired namespacedv1alpha1.ExtensionParameters) bool {
-	if desired.Version == nil || (observed.Version != nil && *desired.Version == *observed.Version) {
-		return true
-	}
-	return false
+	return ptr.Equal(observed.Version, desired.Version) && ptr.Equal(observed.Schema, desired.Schema)
 }
 
 func lateInit(observed namespacedv1alpha1.ExtensionParameters, desired *namespacedv1alpha1.ExtensionParameters) bool {
@@ -192,6 +229,11 @@ func lateInit(observed namespacedv1alpha1.ExtensionParameters, desired *namespac
 
 	if desired.Version == nil && observed.Version != nil {
 		desired.Version = observed.Version
+		li = true
+	}
+
+	if desired.Schema == nil && observed.Schema != nil {
+		desired.Schema = observed.Schema
 		li = true
 	}
 

--- a/pkg/controller/namespaced/postgresql/extension/reconciler_test.go
+++ b/pkg/controller/namespaced/postgresql/extension/reconciler_test.go
@@ -305,6 +305,7 @@ func TestObserve(t *testing.T) {
 					Spec: v1alpha1.ExtensionSpec{
 						ForProvider: v1alpha1.ExtensionParameters{
 							Version: new(string),
+							Schema:  new(string),
 						},
 					},
 				},
@@ -341,6 +342,33 @@ func TestObserve(t *testing.T) {
 					ResourceExists:          true,
 					ResourceUpToDate:        true,
 					ResourceLateInitialized: true,
+				},
+			},
+		},
+		"SchemaMismatch": {
+			reason: "Installed in another schema than desired: not up to date",
+			fields: fields{
+				db: mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*dest[0].(*string) = "1.8"
+						*dest[1].(*string) = "public"
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Version: new("1.8"),
+							Schema:  new("gis"),
+						},
+					},
+				},
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists: true,
 				},
 			},
 		},
@@ -417,6 +445,30 @@ func TestCreate(t *testing.T) {
 				err: nil,
 			},
 		},
+		"WithSchema": {
+			reason: "Schema is appended, quoted, after the version",
+			fields: fields{
+				db: &mockDB{
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						if q.String != `CREATE EXTENSION IF NOT EXISTS "postgis" WITH VERSION "3.6.0" SCHEMA "Mixed Case"` {
+							return errors.New(q.String)
+						}
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Extension: "postgis",
+							Version:   new("3.6.0"),
+							Schema:    new("Mixed Case"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -434,6 +486,8 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	errBoom := errors.New("boom")
+
 	type fields struct {
 		db xsql.DB
 	}
@@ -472,6 +526,58 @@ func TestUpdate(t *testing.T) {
 			},
 			want: want{
 				err: nil,
+			},
+		},
+		"SchemaUnchanged": {
+			reason: "No statement when the extension already is in the desired schema",
+			fields: fields{
+				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*dest[1].(*string) = "gis"
+						return nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error { return errors.New(q.String) },
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Extension: "hstore",
+							Schema:    new("gis"),
+						},
+					},
+				},
+			},
+		},
+		"SchemaMoved": {
+			reason: "A differing schema is fixed with ALTER EXTENSION ... SET SCHEMA; its error is wrapped",
+			fields: fields{
+				db: &mockDB{
+					MockScan: func(ctx context.Context, q xsql.Query, dest ...interface{}) error {
+						*dest[1].(*string) = "public"
+						return nil
+					},
+					MockExec: func(ctx context.Context, q xsql.Query) error {
+						if q.String != `ALTER EXTENSION "hstore" SET SCHEMA "gis"` {
+							return errors.New(q.String)
+						}
+						return errBoom
+					},
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Extension{
+					Spec: v1alpha1.ExtensionSpec{
+						ForProvider: v1alpha1.ExtensionParameters{
+							Extension: "hstore",
+							Schema:    new("gis"),
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errAlterExtension),
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

`spec.forProvider.schema` on `Extension` was accepted by the CRD but never read. Every extension landed in the connection's default schema, and non-relocatable extensions (postgis) cannot be moved afterwards.

- `Create` appends `SCHEMA <name>` to `CREATE EXTENSION`.
- `Observe` reads `pg_namespace.nspname` next to `extversion`, compares it verbatim with the spec, and late-initialises `schema` like `version`.
- `Update` moves relocatable extensions with `ALTER EXTENSION … SET SCHEMA`. For non-relocatable ones the engine's `does not support SET SCHEMA` surfaces in `Synced`. Update re-observes first, so a version-only mismatch still issues no statement.
- Both trees (cluster and namespaced), CRD doc comment regenerated.

Semantics worth a reviewer's attention:

- The schema must exist. A missing schema fails `Create` with postgres' `schema "x" does not exist`.
- Comparison is exact string equality on the raw identifier. Quoting on write (`QuoteIdentifier`) and `nspname` on read round-trip mixed case, spaces and hyphens.
- Existing resources without `schema` late-initialise to their current schema (usually `public`); nothing moves.
- Existing resources that already had `schema` set but ignored will now try to move the extension. Relocatable: it moves. Non-relocatable: `Synced=False` with the engine error until the spec matches reality. Before upgrading, compare specs against `SELECT extname, extnamespace::regnamespace FROM pg_extension` and fix or drop `schema` where they disagree.

Fixes #440

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review. (Locally as `GOTOOLCHAIN=go1.26.1 make lint`, `make test`, `make check-diff`; the pinned golangci-lint build panics under Go 1.27.)

### How has this code been tested

- Unit (`reconciler_test.go`, both trees): Observe schema mismatch, Create statement with version and quoted schema, Update no-op when the schema matches and `ALTER EXTENSION … SET SCHEMA` when it differs.
- E2E core flow: the `ltree` example now installs into `my-schema`; `check_extension_test` asserts `hstore=public ltree=my-schema` from `pg_extension`. Stock `postgres:18` image, no new dependencies.
- Temporary e2e tests (not part of this PR; on my fork, branch `worktree-custom-db-scripts`, `cluster/local/scripts/postgres-issue-440-extension-schema/`) against `imresamu/postgis:18-3.6` (postgres 18, postgis 3.6.1), both cluster and namespaced passes:
  1. postgis → `gis`, hstore → `"Mixed Case"`, schema-less pg_trgm → `public` and late-init `schema: public`; ltree → missing schema stays not Ready with `schema "nope" does not exist`.
  2. Forced re-reconcile keeps `Ready` with an unchanged transition time.
  3. Out-of-band `ALTER EXTENSION hstore SET SCHEMA public` is reverted by Update.
  4. Patching postgis to `schema: public` gives `Synced=False` with `does not support SET SCHEMA`; patching back recovers.
  5. Deleting all leaves no extension behind; schemas survive.

`DB_TYPES=postgresql make e2e` green on both passes (cluster 118 s, namespaced 111 s), temporary tests `i440: PASS` on both.

[contribution process]: https://git.io/fj2m9

