### PR TITLE
Return COMMIT errors from PostgreSQL ExecTx and Close conn on BeginTx error

### DIFF
--- a/pkg/clients/postgresql/postgresql.go
+++ b/pkg/clients/postgresql/postgresql.go
@@ -67,30 +67,26 @@ func (c postgresDB) ExecTx(ctx context.Context, ql []xsql.Query) error {
 	if err != nil {
 		return err
 	}
+	defer d.Close() //nolint:errcheck
 
+	return execTx(ctx, d, ql)
+}
+
+// execTx runs ql in one transaction on d.
+func execTx(ctx context.Context, d *sql.DB, ql []xsql.Query) error {
 	tx, err := d.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
-
-	// Rollback or Commit based on error state. Defer close in defer to make
-	// sure the connection is always closed.
-	defer func() {
-		defer d.Close() //nolint:errcheck
-		// We always rollback, it's a no-op if the tx was already committed.
-		defer tx.Rollback() //nolint:errcheck
-
-		if err == nil {
-			err = tx.Commit()
-		}
-	}()
+	// No-op once Commit has run.
+	defer tx.Rollback() //nolint:errcheck
 
 	for _, q := range ql {
-		if _, err = tx.Exec(q.String, q.Parameters...); err != nil {
+		if _, err := tx.Exec(q.String, q.Parameters...); err != nil {
 			return err
 		}
 	}
-	return err
+	return tx.Commit()
 }
 
 // Exec the supplied query.

--- a/pkg/clients/postgresql/postgresql_test.go
+++ b/pkg/clients/postgresql/postgresql_test.go
@@ -1,7 +1,14 @@
 package postgresql
 
 import (
+	"context"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/crossplane-contrib/provider-sql/pkg/clients/xsql"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
 )
 
 func TestDSNURLEscaping(t *testing.T) {
@@ -15,5 +22,85 @@ func TestDSNURLEscaping(t *testing.T) {
 	dsn := DSN(user, rawPass, endpoint, port, db, sslmode)
 	if dsn != "postgres://"+user+":"+encPass+"@"+endpoint+":"+port+"/"+db+"?sslmode="+sslmode {
 		t.Errorf("DSN string did not match expected output with userinfo URL encoded")
+	}
+}
+
+func TestExecTx(t *testing.T) {
+	errBoom := errors.New("boom")
+	usage := xsql.Query{String: "GRANT USAGE ON SCHEMA s TO r"}
+	selct := xsql.Query{String: "GRANT SELECT ON ALL TABLES IN SCHEMA s TO r"}
+	ok := sqlmock.NewResult(0, 0)
+
+	cases := map[string]struct {
+		ql     []xsql.Query
+		expect func(sqlmock.Sqlmock)
+		want   error
+	}{
+		"Commits": {
+			ql: []xsql.Query{usage, selct},
+			expect: func(m sqlmock.Sqlmock) {
+				m.ExpectBegin()
+				m.ExpectExec("GRANT USAGE").WillReturnResult(ok)
+				m.ExpectExec("GRANT SELECT").WillReturnResult(ok)
+				m.ExpectCommit()
+			},
+		},
+		"ReturnsBeginError": {
+			ql: []xsql.Query{usage},
+			expect: func(m sqlmock.Sqlmock) {
+				m.ExpectBegin().WillReturnError(errBoom)
+			},
+			want: errBoom,
+		},
+		"RollsBackOnExecError": {
+			ql: []xsql.Query{usage},
+			expect: func(m sqlmock.Sqlmock) {
+				m.ExpectBegin()
+				m.ExpectExec("GRANT USAGE").WillReturnError(errBoom)
+				m.ExpectRollback()
+			},
+			want: errBoom,
+		},
+		// A later statement failing must not commit the earlier ones.
+		"RollsBackOnLaterExecError": {
+			ql: []xsql.Query{usage, selct},
+			expect: func(m sqlmock.Sqlmock) {
+				m.ExpectBegin()
+				m.ExpectExec("GRANT USAGE").WillReturnResult(ok)
+				m.ExpectExec("GRANT SELECT").WillReturnError(errBoom)
+				m.ExpectRollback()
+			},
+			want: errBoom,
+		},
+		// COMMIT can fail after every statement succeeded, e.g. a deferred
+		// constraint trigger. The error must reach the caller.
+		"ReturnsCommitError": {
+			ql: []xsql.Query{usage},
+			expect: func(m sqlmock.Sqlmock) {
+				m.ExpectBegin()
+				m.ExpectExec("GRANT USAGE").WillReturnResult(ok)
+				m.ExpectCommit().WillReturnError(errBoom)
+			},
+			want: errBoom,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			tc.expect(mock)
+
+			got := execTx(context.Background(), db, tc.ql)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("execTx(): -want, +got:\n%s", diff)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Description of your changes

There were two subtle bugs in ExecTx, the return value from Commit was assigned to err, which would only work if err was a named return variable. Additionally, the *sql.Conn handle including a goroutine would leak if BeginTx failed, like if there's an issue with the providerconfig.

To add testing we extract the main code to execTx and test using sqlmock. To remove the bug and make the code easier to understand and more standard, follow the code structure more like used in stdlib docs: https://pkg.go.dev/database/sql#Tx.Prepare

Fixes issue found by agent inspection.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Unit test, and also manual testing in e2e (not added here to keep runtime low) with a trigger causing the COMMIT to fail. It didn't return any error without this fix, synced became true.

[contribution process]: https://git.io/fj2m9
