### PR TITLE
docs: document PostgreSQL Role password rotation trigger

### DIFF
--- a/examples/password-rotation.yaml
+++ b/examples/password-rotation.yaml
@@ -1,0 +1,70 @@
+# PostgreSQL Role password management
+#
+# provider-sql manages a PostgreSQL Role's password in one of two ways,
+# selected by whether `passwordSecretRef` is set.
+#
+# 1. Auto-generated (default). When `passwordSecretRef` is omitted, the
+#    provider generates a random password when the Role is created and stores
+#    it in the connection secret referenced by `writeConnectionSecretToRef`.
+#    It records when it last did so in `status.atProvider.lastPasswordChange`.
+#
+#    To rotate the password, set `passwordRotationTrigger` to a timestamp that
+#    is later than `status.atProvider.lastPasswordChange`. On the next
+#    reconcile the provider generates a fresh password and updates the
+#    connection secret, then bumps `lastPasswordChange`. Rotating again later
+#    simply requires moving `passwordRotationTrigger` past the new
+#    `lastPasswordChange`.
+#
+# 2. Bring-your-own-password (BYOP). When `passwordSecretRef` is set, the
+#    referenced secret is the source of truth and the provider never generates
+#    or rotates the password. `passwordRotationTrigger` has no effect in this
+#    mode.
+#
+# Restoring a Role out of band (for example from a backup) leaves
+# `status.atProvider.lastPasswordChange` empty. In that case, if the connection
+# secret is missing or has no password, the provider generates a fresh password
+# on the next reconcile so the Role is usable again.
+#
+# This example uses the namespaced PostgreSQL API to avoid redundancy; the same
+# fields behave identically for cluster-scoped roles
+# (apiVersion postgresql.sql.crossplane.io/v1alpha1).
+---
+# Auto-generated password with rotation.
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Role
+metadata:
+  name: example-role
+  namespace: default
+spec:
+  forProvider:
+    privileges:
+      login: true
+    # Rotate the auto-generated password whenever this timestamp is newer than
+    # status.atProvider.lastPasswordChange. Remove (or leave unset) to disable
+    # rotation.
+    passwordRotationTrigger: "2026-09-10T00:00:00Z"
+  writeConnectionSecretToRef:
+    name: example-role-secret
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default
+---
+# Bring-your-own-password: provider-sql reads the password from an existing
+# secret and never generates or rotates it.
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Role
+metadata:
+  name: byop-role
+  namespace: default
+spec:
+  forProvider:
+    privileges:
+      login: true
+    passwordSecretRef:
+      name: byop-password
+      key: password
+  writeConnectionSecretToRef:
+    name: byop-role-secret
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default


### PR DESCRIPTION
## Description

Documents the PostgreSQL `Role` password management behavior introduced in #348, which was previously only explained in the PR itself (see #443).

Adds a commented example covering:

- **Auto-generated passwords** (default when `passwordSecretRef` is omitted) and how to rotate them with `spec.forProvider.passwordRotationTrigger` (set to a timestamp later than `status.atProvider.lastPasswordChange`).
- **Bring-your-own-password** via `passwordSecretRef`, where the provider never generates or rotates the password and `passwordRotationTrigger` has no effect.
- The **out-of-band restore** behavior, where a missing/empty connection secret triggers a fresh password generation.

Fixes #443

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

[contribution process]: https://crossplane.io/docs/latest/contributing/contributing/