### PR TITLE
fix(postgresql): reject memberOf grants that also set database or privileges

### DIFF
--- a/apis/cluster/postgresql/v1alpha1/grant_types.go
+++ b/apis/cluster/postgresql/v1alpha1/grant_types.go
@@ -304,6 +304,8 @@ type Routine struct {
 
 // GrantParameters define the desired state of a PostgreSQL grant instance.
 // +kubebuilder:validation:XValidation:rule="!has(self.withInherit) || has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector)",message="withInherit may only be set on memberOf grants"
+// +kubebuilder:validation:XValidation:rule="!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector)) || (!has(self.database) && !has(self.databaseRef) && !has(self.databaseSelector))",message="database, databaseRef and databaseSelector cannot be set in the same grant as memberOf"
+// +kubebuilder:validation:XValidation:rule="!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector)) || !has(self.privileges)",message="privileges cannot be set in the same grant as memberOf"
 type GrantParameters struct {
 	// Privileges to be granted.
 	// See https://www.postgresql.org/docs/current/sql-grant.html for available privileges.

--- a/apis/namespaced/postgresql/v1alpha1/grant_types.go
+++ b/apis/namespaced/postgresql/v1alpha1/grant_types.go
@@ -304,6 +304,8 @@ type Routine struct {
 
 // GrantParameters define the desired state of a PostgreSQL grant instance.
 // +kubebuilder:validation:XValidation:rule="!has(self.withInherit) || has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector)",message="withInherit may only be set on memberOf grants"
+// +kubebuilder:validation:XValidation:rule="!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector)) || (!has(self.database) && !has(self.databaseRef) && !has(self.databaseSelector))",message="database, databaseRef and databaseSelector cannot be set in the same grant as memberOf"
+// +kubebuilder:validation:XValidation:rule="!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector)) || !has(self.privileges)",message="privileges cannot be set in the same grant as memberOf"
 type GrantParameters struct {
 	// Privileges to be granted.
 	// See https://www.postgresql.org/docs/current/sql-grant.html for available privileges.

--- a/package/crds/postgresql.sql.crossplane.io_grants.yaml
+++ b/package/crds/postgresql.sql.crossplane.io_grants.yaml
@@ -487,6 +487,13 @@ spec:
                 - message: withInherit may only be set on memberOf grants
                   rule: '!has(self.withInherit) || has(self.memberOf) || has(self.memberOfRef)
                     || has(self.memberOfSelector)'
+                - message: database, databaseRef and databaseSelector cannot be set
+                    in the same grant as memberOf
+                  rule: '!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector))
+                    || (!has(self.database) && !has(self.databaseRef) && !has(self.databaseSelector))'
+                - message: privileges cannot be set in the same grant as memberOf
+                  rule: '!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector))
+                    || !has(self.privileges)'
               managementPolicies:
                 default:
                 - '*'

--- a/package/crds/postgresql.sql.m.crossplane.io_grants.yaml
+++ b/package/crds/postgresql.sql.m.crossplane.io_grants.yaml
@@ -497,6 +497,13 @@ spec:
                 - message: withInherit may only be set on memberOf grants
                   rule: '!has(self.withInherit) || has(self.memberOf) || has(self.memberOfRef)
                     || has(self.memberOfSelector)'
+                - message: database, databaseRef and databaseSelector cannot be set
+                    in the same grant as memberOf
+                  rule: '!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector))
+                    || (!has(self.database) && !has(self.databaseRef) && !has(self.databaseSelector))'
+                - message: privileges cannot be set in the same grant as memberOf
+                  rule: '!(has(self.memberOf) || has(self.memberOfRef) || has(self.memberOfSelector))
+                    || !has(self.privileges)'
               managementPolicies:
                 default:
                 - '*'


### PR DESCRIPTION
### Description of your changes

`Grant` (both `postgresql.sql.crossplane.io` and `postgresql.sql.m.crossplane.io`) accepted `memberOf` / `memberOfRef` / `memberOfSelector` together with `database` / `databaseRef` / `databaseSelector`, or together with `privileges`. Neither combination can ever reconcile: `resolveGrantType()` in the grant reconcilers returns `cannot set privileges or database in the same grant as memberOf`, so the object is accepted by the API server and then fails on every reconcile.

This adds two `XValidation` rules to `GrantParameters` that mirror that guard, so the invalid combination is rejected at write time with a message naming the conflicting fields:

- `database`, `databaseRef` and `databaseSelector` cannot be set together with `memberOf`, `memberOfRef` or `memberOfSelector`
- `privileges` cannot be set together with `memberOf`, `memberOfRef` or `memberOfSelector`

Valid manifests are unaffected: `memberOf` alone (with or without `withInherit`), and the database / schema / table / column / sequence / routine / foreign* grants with `privileges`. Only the two combinations the reconciler already rejects are now rejected earlier, at admission.

I kept the rules aligned with the existing `resolveGrantType` guard instead of expressing the whole grant-type matrix in CEL: today a `memberOf` grant that also sets `schema` or `tables` is silently ignored by the reconciler rather than rejected, and tightening that is a separate discussion.

Fixes #406

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- `go build ./...`, `go vet ./apis/... ./pkg/...`, `gofmt -l apis pkg` and `go test ./apis/... ./pkg/... -count=1` all pass.
- CRDs regenerated with the repo's own `generate` tooling (the pinned controller-gen from `go.mod`); the resulting diff is limited to the two new rules in the cluster and namespaced Grant CRDs.
- Validated the generated CRD with the API server's own validation packages (`apiextensions-apiserver/pkg/apis/apiextensions/validation` for rule compilation, and `apiserver/schema/cel` for rule behaviour). Accept/reject samples below; dropping the two rules flips the rejected samples back to accepted, which is the pre-fix behaviour.
- `make reviewable` runs generate and the unit tests cleanly here, but its lint step panics locally with the prebuilt golangci-lint binary (a `go/types` panic in the linter's own toolchain, unrelated to this change), so lint is left to CI.

Accepted (unchanged): `{role, memberOf}`, `{role, memberOfRef}`, `{role, memberOfSelector}`, `{role, memberOf, withInherit}`, `{role, database, privileges}`, `{role, database, schema, privileges}`, `{role, database, schema, tables, privileges}`.

Rejected (new): `{role, memberOf, database}`, `{role, memberOf, databaseRef}`, `{role, memberOf, databaseSelector}`, `{role, memberOfRef, databaseSelector}`, `{role, memberOf, privileges}`.

[contribution process]: https://git.io/fj2m9
